### PR TITLE
[codex] 140 folder date range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 ## Required context pack (read before implementing a slice)
 - Mandatory baseline for every slice:
   - `docs/checklists/v1.md`
+  - `docs/conventions.md`
   - `docs/specs/040-architecture.md`
   - `docs/specs/050-workplan.md`
   - `docs/specs/060-plan-schema.md`
@@ -88,3 +89,4 @@
 ## Docs
 - Specs live under `docs/specs/`.
 - Delivery checklists live under `docs/checklists/`.
+- Implementation conventions live under `docs/conventions.md`.

--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -18,7 +18,7 @@
 - [x] 110 Core contract models (`docs/specs/110-core-contract-models.md`)
 - [x] 120 Serilog CLI bootstrap (`docs/specs/120-serilog-cli-bootstrap.md`)
 - [x] 130 EXIF reader JPEG/NEF (`docs/specs/130-exif-reader-jpeg-nef.md`)
-- [ ] 140 Folder date range (`docs/specs/140-folder-date-range.md`)
+- [x] 140 Folder date range (`docs/specs/140-folder-date-range.md`)
 - [ ] 150 Name generation (`docs/specs/150-name-generation.md`)
 - [ ] 160 Conflict retry policy (`docs/specs/160-conflict-retry-policy.md`)
 - [ ] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,41 @@
+# Implementation Conventions
+
+This document captures repo-specific implementation defaults that complement the architecture and engineering contract. Keep it short, concrete, and enforceable in review.
+
+## Design defaults
+- Prefer small, testable classes with one clear responsibility.
+- Use constructor injection for services and external dependencies.
+- Keep orchestration at application boundaries and business logic in core services.
+- Depend on abstractions at boundaries when a dependency touches IO, time, environment, or third-party libraries.
+- Prefer explicit inputs and outputs over ambient state, static singletons, or hidden side effects.
+
+## CQS and side effects
+- Favor command-query separation where it improves clarity and testability.
+- Query paths should not perform writes, mutations, or surprising logging-driven behavior.
+- Commands should make side effects explicit in their contract and return a result that is easy to assert in tests.
+
+## Boundary rules
+- Keep `Renamer.Core` free of CLI and UI concerns.
+- Treat CLI and UI projects as composition and delivery layers over core behavior.
+- Keep serialization, filesystem access, clock access, and external library integration behind focused interfaces when practical.
+
+## Logging and errors
+- Prefer structured logs with stable property names over interpolated-only messages.
+- Log at the boundary where context is richest; avoid spreading logging through pure domain logic unless it is operationally important.
+- Prefer explicit result models and domain-specific exceptions over vague catch-all behavior.
+
+## Testing defaults
+- Add or update tests with behavior changes.
+- Favor fast unit tests for core rules and focused integration tests for boundary wiring.
+- Design APIs so core logic can be exercised without filesystem, clock, or process-global state.
+
+## What to avoid
+- Service location, hidden globals, and static state that make tests order-dependent.
+- Mixing orchestration, IO, parsing, and domain decisions in one class.
+- Read methods that also mutate state or perform writes unless the behavior is explicit and justified.
+- Drive-by refactors outside the active slice or task scope.
+
+## Related docs
+- Architecture boundaries: `docs/specs/040-architecture.md`
+- Engineering contract and test gates: `docs/specs/070-engineering-contract.md`
+- Slice execution workflow: `AGENTS.md`

--- a/src/Renamer.Core/Planning/FolderDateRangeCalculator.cs
+++ b/src/Renamer.Core/Planning/FolderDateRangeCalculator.cs
@@ -1,0 +1,29 @@
+using Renamer.Core.Exif;
+
+namespace Renamer.Core.Planning;
+
+public sealed class FolderDateRangeCalculator : IFolderDateRangeCalculator
+{
+    public FolderDateRangeResult Calculate(IEnumerable<ExifReadResult> photoMetadata)
+    {
+        ArgumentNullException.ThrowIfNull(photoMetadata);
+
+        DateOnly? minDate = null;
+        DateOnly? maxDate = null;
+
+        foreach (var metadata in photoMetadata)
+        {
+            if (metadata.CaptureDate is not { } captureDate)
+            {
+                continue;
+            }
+
+            minDate = minDate is null || captureDate < minDate ? captureDate : minDate;
+            maxDate = maxDate is null || captureDate > maxDate ? captureDate : maxDate;
+        }
+
+        return minDate is { } startDate && maxDate is { } endDate
+            ? FolderDateRangeResult.Plannable(startDate, endDate)
+            : FolderDateRangeResult.NonPlannable();
+    }
+}

--- a/src/Renamer.Core/Planning/FolderDateRangeResult.cs
+++ b/src/Renamer.Core/Planning/FolderDateRangeResult.cs
@@ -1,0 +1,24 @@
+namespace Renamer.Core.Planning;
+
+public sealed record FolderDateRangeResult
+{
+    public required bool IsPlannable { get; init; }
+
+    public DateOnly? StartDate { get; init; }
+
+    public DateOnly? EndDate { get; init; }
+
+    public static FolderDateRangeResult Plannable(DateOnly startDate, DateOnly endDate) => new()
+    {
+        IsPlannable = true,
+        StartDate = startDate,
+        EndDate = endDate
+    };
+
+    public static FolderDateRangeResult NonPlannable() => new()
+    {
+        IsPlannable = false,
+        StartDate = null,
+        EndDate = null
+    };
+}

--- a/src/Renamer.Core/Planning/IFolderDateRangeCalculator.cs
+++ b/src/Renamer.Core/Planning/IFolderDateRangeCalculator.cs
@@ -1,0 +1,8 @@
+using Renamer.Core.Exif;
+
+namespace Renamer.Core.Planning;
+
+public interface IFolderDateRangeCalculator
+{
+    FolderDateRangeResult Calculate(IEnumerable<ExifReadResult> photoMetadata);
+}

--- a/src/Renamer.Tests/Core/DateRangeTests.cs
+++ b/src/Renamer.Tests/Core/DateRangeTests.cs
@@ -1,0 +1,71 @@
+using Renamer.Core.Exif;
+using Renamer.Core.Planning;
+
+namespace Renamer.Tests.Core;
+
+public sealed class DateRangeTests
+{
+    [Fact]
+    public void Calculate_MixedValidAndMissingDates_ReturnsMinAndMaxFromValidDates()
+    {
+        var sut = new FolderDateRangeCalculator();
+        ExifReadResult[] metadata =
+        [
+            ExifReadResult.MissingExif(),
+            ExifReadResult.Supported(new DateOnly(2024, 6, 14)),
+            ExifReadResult.InvalidExif(),
+            ExifReadResult.Supported(new DateOnly(2024, 6, 12)),
+            ExifReadResult.Supported(new DateOnly(2024, 6, 16))
+        ];
+
+        var result = sut.Calculate(metadata);
+
+        Assert.True(result.IsPlannable);
+        Assert.Equal(new DateOnly(2024, 6, 12), result.StartDate);
+        Assert.Equal(new DateOnly(2024, 6, 16), result.EndDate);
+    }
+
+    [Fact]
+    public void Calculate_SingleValidDate_ReturnsSameStartAndEndDate()
+    {
+        var sut = new FolderDateRangeCalculator();
+        ExifReadResult[] metadata =
+        [
+            ExifReadResult.Unsupported(),
+            ExifReadResult.Supported(new DateOnly(2024, 1, 5))
+        ];
+
+        var result = sut.Calculate(metadata);
+
+        Assert.True(result.IsPlannable);
+        Assert.Equal(new DateOnly(2024, 1, 5), result.StartDate);
+        Assert.Equal(new DateOnly(2024, 1, 5), result.EndDate);
+    }
+
+    [Fact]
+    public void Calculate_AllMissingDates_ReturnsNonPlannableResult()
+    {
+        var sut = new FolderDateRangeCalculator();
+        ExifReadResult[] metadata =
+        [
+            ExifReadResult.MissingExif(),
+            ExifReadResult.InvalidExif(),
+            ExifReadResult.ReadFailure(),
+            ExifReadResult.Unsupported()
+        ];
+
+        var result = sut.Calculate(metadata);
+
+        Assert.False(result.IsPlannable);
+        Assert.Null(result.StartDate);
+        Assert.Null(result.EndDate);
+    }
+
+    [Fact]
+    public void Calculate_NullMetadata_ThrowsArgumentNullException()
+    {
+        var sut = new FolderDateRangeCalculator();
+
+        Assert.Throws<ArgumentNullException>(() => sut.Calculate(null!));
+    }
+}


### PR DESCRIPTION
This change completes slice 140 by adding the core folder date range calculation that the planner will use to derive rename prefixes from photo metadata. Before this, the codebase could read EXIF capture dates per file but had no focused core service for collapsing those results into a plannable folder-level start and end date, which blocked the next naming and planning slices.

The user-visible effect is that folders can now be classified as plannable when at least one valid capture date exists, and non-plannable when all files are missing usable dates. The implementation keeps this logic isolated in `Renamer.Core` with a small calculator and result model so later planner slices can consume it without taking a dependency on CLI or UI concerns. The included tests cover mixed valid and missing EXIF results, the single-date boundary case, the all-missing case, and null input handling.

This PR also includes the admin/documentation updates currently staged on the branch. `docs/conventions.md` adds repository implementation conventions, and `AGENTS.md` now points future slice work at that document as part of the required context pack.

Validation for the code changes was run locally with `dotnet build Renamer.sln` and `dotnet test Renamer.sln --filter "FullyQualifiedName~DateRange"`, both of which passed.
