### PR TITLE
[codex] 150 name generation

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -19,7 +19,7 @@
 - [x] 120 Serilog CLI bootstrap (`docs/specs/120-serilog-cli-bootstrap.md`)
 - [x] 130 EXIF reader JPEG/NEF (`docs/specs/130-exif-reader-jpeg-nef.md`)
 - [x] 140 Folder date range (`docs/specs/140-folder-date-range.md`)
-- [ ] 150 Name generation (`docs/specs/150-name-generation.md`)
+- [x] 150 Name generation (`docs/specs/150-name-generation.md`)
 - [ ] 160 Conflict retry policy (`docs/specs/160-conflict-retry-policy.md`)
 - [ ] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)
 - [ ] 180 Apply engine (`docs/specs/180-apply-engine.md`)

--- a/src/Renamer.Core/Planning/FolderNameGenerator.cs
+++ b/src/Renamer.Core/Planning/FolderNameGenerator.cs
@@ -1,0 +1,15 @@
+namespace Renamer.Core.Planning;
+
+public sealed class FolderNameGenerator : IFolderNameGenerator
+{
+    public string Generate(string sourceFolderName, DateOnly startDate, DateOnly endDate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceFolderName);
+
+        var prefix = startDate == endDate
+            ? startDate.ToString("yyyy-MM-dd")
+            : $"{startDate:yyyy-MM-dd} - {endDate:yyyy-MM-dd}";
+
+        return $"{prefix} - {sourceFolderName}";
+    }
+}

--- a/src/Renamer.Core/Planning/IFolderNameGenerator.cs
+++ b/src/Renamer.Core/Planning/IFolderNameGenerator.cs
@@ -1,0 +1,6 @@
+namespace Renamer.Core.Planning;
+
+public interface IFolderNameGenerator
+{
+    string Generate(string sourceFolderName, DateOnly startDate, DateOnly endDate);
+}

--- a/src/Renamer.Tests/Core/NameGenerationTests.cs
+++ b/src/Renamer.Tests/Core/NameGenerationTests.cs
@@ -1,0 +1,44 @@
+using Renamer.Core.Planning;
+
+namespace Renamer.Tests.Core;
+
+public sealed class NameGenerationTests
+{
+    [Fact]
+    public void Generate_SingleDay_FormatsDateThenOriginalFolderName()
+    {
+        var sut = new FolderNameGenerator();
+
+        var result = sut.Generate("Trip A", new DateOnly(2024, 6, 12), new DateOnly(2024, 6, 12));
+
+        Assert.Equal("2024-06-12 - Trip A", result);
+    }
+
+    [Fact]
+    public void Generate_MultiDay_FormatsStartAndEndDatesThenOriginalFolderName()
+    {
+        var sut = new FolderNameGenerator();
+
+        var result = sut.Generate("Trip A", new DateOnly(2024, 6, 12), new DateOnly(2024, 6, 14));
+
+        Assert.Equal("2024-06-12 - 2024-06-14 - Trip A", result);
+    }
+
+    [Fact]
+    public void Generate_PreservesSpacesAndPunctuationInFolderName()
+    {
+        var sut = new FolderNameGenerator();
+
+        var result = sut.Generate("Trip, Day 1! (RAW + JPG)", new DateOnly(2024, 1, 5), new DateOnly(2024, 1, 5));
+
+        Assert.Equal("2024-01-05 - Trip, Day 1! (RAW + JPG)", result);
+    }
+
+    [Fact]
+    public void Generate_EmptyFolderName_ThrowsArgumentException()
+    {
+        var sut = new FolderNameGenerator();
+
+        Assert.Throws<ArgumentException>(() => sut.Generate(string.Empty, new DateOnly(2024, 1, 5), new DateOnly(2024, 1, 5)));
+    }
+}


### PR DESCRIPTION
This change completes slice 150 by adding the core name-generation helper that turns a source folder name plus a computed date range into the canonical destination name format required by the v1 schema. Before this, the project could read EXIF capture dates and compute folder-level date ranges, but it still lacked the deterministic formatting step needed for planned destination paths.

The user-visible effect is that a planner can now consistently generate either `YYYY-MM-DD - <folder name>` for single-day folders or `YYYY-MM-DD - YYYY-MM-DD - <folder name>` for multi-day folders. The implementation preserves the original folder name verbatim, including spaces and punctuation, so later slices can compose planned paths without changing the user’s original folder text.

The root cause of the missing behavior was that no focused core service existed for date-based folder name formatting. This PR adds a narrow `FolderNameGenerator` contract and implementation under `Renamer.Core.Planning`, plus targeted tests that cover the single-day case, the multi-day case, punctuation and spacing preservation, and invalid empty folder names.

Validation was run locally with `dotnet build Renamer.sln` and `dotnet test Renamer.sln --filter "FullyQualifiedName~NameGeneration"`, both of which passed.
