### PR TITLE
[codex] add git workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,14 @@
   3. `git pull --ff-only origin main`.
   4. `git switch -c codex/<slice-id>-<slice-name>`.
   5. Confirm branch name matches the active slice.
-- Only after preflight passes: implement one slice, run slice-required commands/tests, then update `docs/checklists/v1.md`.
+  6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches the active slice.
+- Only after preflight passes: implement one slice, run slice-required commands/tests, open a PR linked to the corresponding issue, then update `docs/checklists/v1.md`.
 
 ## Required context pack (read before implementing a slice)
 - Mandatory baseline for every slice:
   - `docs/checklists/v1.md`
   - `docs/conventions.md`
+  - `docs/git-workflow.md`
   - `docs/specs/040-architecture.md`
   - `docs/specs/050-workplan.md`
   - `docs/specs/060-plan-schema.md`
@@ -90,3 +92,4 @@
 - Specs live under `docs/specs/`.
 - Delivery checklists live under `docs/checklists/`.
 - Implementation conventions live under `docs/conventions.md`.
+- Git and GitHub workflow guidance lives under `docs/git-workflow.md`.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,43 @@
+# Git Workflow
+
+This document defines the repo's Git and GitHub issue workflow around slice pickup, implementation, and PR close-out.
+
+## Slice pickup preflight
+Complete these steps before editing code for a new slice:
+
+1. Confirm the working tree is clean:
+   - `git status --short`
+2. Confirm the current branch is `main`:
+   - `git branch --show-current`
+3. Fast-forward local `main`:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main`:
+   - `git switch -c codex/<slice-id>-<slice-name>`
+5. Confirm branch name matches the active slice:
+   - `git branch --show-current`
+6. If a matching GitHub issue exists for the slice:
+   - move it to `In Progress` in the GitHub project
+   - confirm the issue title and slice ID match the branch and spec
+
+## Working rules
+- One slice per branch.
+- One branch per PR.
+- Keep commits scoped to the active slice only.
+- Do not mix unrelated cleanup or refactors into slice branches.
+
+## PR close-out
+When opening a PR for a slice:
+
+1. Use the slice ID in the PR title.
+2. Link the corresponding GitHub issue in the PR body:
+   - prefer `Closes #<issue-number>` when the PR is intended to complete the slice
+   - use `Refs #<issue-number>` only when the PR is partial or non-closing
+3. Confirm the linked issue is in `In Progress` before requesting review.
+4. Keep the PR scoped to the slice spec and acceptance checks only.
+5. After merge:
+   - update `docs/checklists/v1.md`
+   - confirm the GitHub issue is closed by the PR merge
+
+## Notes
+- Specs remain the source of truth; GitHub issues and PRs are execution tracking artifacts.
+- If no GitHub issue exists yet for a slice, continue with the documented Git preflight and create or backfill the issue separately.

--- a/docs/specs/100-slice-template.md
+++ b/docs/specs/100-slice-template.md
@@ -23,7 +23,8 @@ One-sentence outcome.
    - `git switch -c codex/XXX-name`
 5. Confirm branch naming matches this slice ID:
    - `git branch --show-current` equals `codex/XXX-name`.
-6. Do not edit code until steps 1-5 are complete.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit code until steps 1-6 are complete.
 
 ## Implementation steps
 1. Step 1.
@@ -40,8 +41,12 @@ One-sentence outcome.
 1. Branch from current `main` using prefix `codex/` (for example `codex/xxx-slice-name`).
 2. Keep one slice per branch and one branch per PR.
 3. Commit only files related to this slice.
-4. Open PR back into `main` with slice ID in title/body.
-5. Include the slice ID in PR title and body.
+4. If a matching GitHub issue exists, ensure it is `In Progress` before opening the PR.
+5. Open PR back into `main` with slice ID in title/body.
+6. Link the corresponding issue in the PR body:
+   - use `Closes #<issue-number>` when the PR completes the slice
+   - use `Refs #<issue-number>` only for partial work
+7. Include the slice ID in PR title and body.
 
 ## Acceptance checks
 - Observable check 1.
@@ -58,6 +63,7 @@ One-sentence outcome.
 
 ## Exit criteria
 - PR merged with passing tests for this slice only.
+- PR links the corresponding GitHub issue when one exists.
 
 ## Definition of Done
 - Acceptance checks in this slice are satisfied.
@@ -66,3 +72,4 @@ One-sentence outcome.
 - Branch pre-implementation gate completed before first code edit.
 - Branch name follows `codex/` and maps to this slice ID.
 - PR scope is limited to this slice (no unrelated refactors).
+- If a matching GitHub issue exists, it is linked from the PR and moved to `In Progress` when the slice is picked up.


### PR DESCRIPTION
## Summary
This change adds explicit Git and GitHub workflow guidance for slice pickup and close-out so issue handling is part of the documented delivery process instead of tribal knowledge. Before this, the repo documented branch preflight and slice scope, but it did not say when to move a matching GitHub issue into `In Progress`, how to link the issue from the PR body, or where that close-out behavior should live.

The effect is that slice work now has a documented tracking loop from branch creation through PR merge. Contributors are instructed to move the corresponding issue into `In Progress` when a slice is picked up, keep the issue and branch aligned to the active slice, and link the PR back to the issue with `Closes #<issue-number>` or `Refs #<issue-number>` as appropriate.

## Root Cause
The repository had good spec and branch discipline, but GitHub issue and PR workflow conventions were implicit. That made it easy for slice work to happen without a consistent issue state transition or PR-to-issue linkage.

## Fix
A new `docs/git-workflow.md` document defines slice pickup preflight, working rules, and PR close-out guidance. `AGENTS.md` now includes that document in the required context pack and updates the deterministic slice start protocol to include moving a matching GitHub issue to `In Progress`. The slice template in `docs/specs/100-slice-template.md` now mirrors the same expectations in both the pre-implementation gate and Git/PR workflow sections.

## Validation
This is a docs-only change. I did not run tests.
