### PR TITLE
[codex] 160 conflict retry policy

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -20,7 +20,7 @@
 - [x] 130 EXIF reader JPEG/NEF (`docs/specs/130-exif-reader-jpeg-nef.md`)
 - [x] 140 Folder date range (`docs/specs/140-folder-date-range.md`)
 - [x] 150 Name generation (`docs/specs/150-name-generation.md`)
-- [ ] 160 Conflict retry policy (`docs/specs/160-conflict-retry-policy.md`)
+- [x] 160 Conflict retry policy (`docs/specs/160-conflict-retry-policy.md`)
 - [ ] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)
 - [ ] 180 Apply engine (`docs/specs/180-apply-engine.md`)
 - [ ] 190 Report JSON writer (`docs/specs/190-report-json-writer.md`)

--- a/src/Renamer.Core/Execution/ConflictRetryFailure.cs
+++ b/src/Renamer.Core/Execution/ConflictRetryFailure.cs
@@ -1,0 +1,6 @@
+namespace Renamer.Core.Execution;
+
+public enum ConflictRetryFailure
+{
+    RetryLimitExceeded
+}

--- a/src/Renamer.Core/Execution/ConflictRetryPolicy.cs
+++ b/src/Renamer.Core/Execution/ConflictRetryPolicy.cs
@@ -1,0 +1,43 @@
+namespace Renamer.Core.Execution;
+
+public sealed class ConflictRetryPolicy : IConflictRetryPolicy
+{
+    public const int MaxSuffixRetries = 10;
+    public const int RetryLimitExitCode = 5;
+
+    public IReadOnlyList<string> GetCandidatePaths(string plannedDestinationPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(plannedDestinationPath);
+
+        var candidates = new List<string>(MaxSuffixRetries + 1)
+        {
+            plannedDestinationPath
+        };
+
+        for (var suffix = 1; suffix <= MaxSuffixRetries; suffix++)
+        {
+            candidates.Add($"{plannedDestinationPath} ({suffix})");
+        }
+
+        return candidates;
+    }
+
+    public ConflictRetryResolution ResolveAvailableDestination(string plannedDestinationPath, Func<string, bool> destinationExists)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(plannedDestinationPath);
+        ArgumentNullException.ThrowIfNull(destinationExists);
+
+        var candidates = GetCandidatePaths(plannedDestinationPath);
+
+        for (var index = 0; index < candidates.Count; index++)
+        {
+            var candidatePath = candidates[index];
+            if (!destinationExists(candidatePath))
+            {
+                return ConflictRetryResolution.Success(candidatePath, index + 1);
+            }
+        }
+
+        return ConflictRetryResolution.RetryLimitExceeded(candidates.Count);
+    }
+}

--- a/src/Renamer.Core/Execution/ConflictRetryResolution.cs
+++ b/src/Renamer.Core/Execution/ConflictRetryResolution.cs
@@ -1,0 +1,34 @@
+namespace Renamer.Core.Execution;
+
+public sealed record ConflictRetryResolution
+{
+    public required bool Succeeded { get; init; }
+
+    public required int Attempts { get; init; }
+
+    public string? ResolvedDestinationPath { get; init; }
+
+    public ConflictRetryFailure? Failure { get; init; }
+
+    public int? SuggestedExitCode { get; init; }
+
+    public bool ShouldAbortPlanExecution => Failure is not null;
+
+    public static ConflictRetryResolution Success(string resolvedDestinationPath, int attempts) => new()
+    {
+        Succeeded = true,
+        Attempts = attempts,
+        ResolvedDestinationPath = resolvedDestinationPath,
+        Failure = null,
+        SuggestedExitCode = null
+    };
+
+    public static ConflictRetryResolution RetryLimitExceeded(int attempts) => new()
+    {
+        Succeeded = false,
+        Attempts = attempts,
+        ResolvedDestinationPath = null,
+        Failure = ConflictRetryFailure.RetryLimitExceeded,
+        SuggestedExitCode = ConflictRetryPolicy.RetryLimitExitCode
+    };
+}

--- a/src/Renamer.Core/Execution/IConflictRetryPolicy.cs
+++ b/src/Renamer.Core/Execution/IConflictRetryPolicy.cs
@@ -1,0 +1,8 @@
+namespace Renamer.Core.Execution;
+
+public interface IConflictRetryPolicy
+{
+    IReadOnlyList<string> GetCandidatePaths(string plannedDestinationPath);
+
+    ConflictRetryResolution ResolveAvailableDestination(string plannedDestinationPath, Func<string, bool> destinationExists);
+}

--- a/src/Renamer.Tests/Core/ConflictRetryPolicyTests.cs
+++ b/src/Renamer.Tests/Core/ConflictRetryPolicyTests.cs
@@ -1,0 +1,63 @@
+using Renamer.Core.Execution;
+
+namespace Renamer.Tests.Core;
+
+public sealed class ConflictRetryPolicyTests
+{
+    [Fact]
+    public void GetCandidatePaths_ReturnsBasePathThenDeterministicSuffixesThroughTen()
+    {
+        var sut = new ConflictRetryPolicy();
+
+        var result = sut.GetCandidatePaths("/photos/2024-06-12 - Trip A");
+
+        Assert.Equal(11, result.Count);
+        Assert.Equal("/photos/2024-06-12 - Trip A", result[0]);
+        Assert.Equal("/photos/2024-06-12 - Trip A (1)", result[1]);
+        Assert.Equal("/photos/2024-06-12 - Trip A (2)", result[2]);
+        Assert.Equal("/photos/2024-06-12 - Trip A (10)", result[10]);
+    }
+
+    [Fact]
+    public void ResolveAvailableDestination_WhenConflictClears_UsesFirstAvailableSuffix()
+    {
+        var sut = new ConflictRetryPolicy();
+        var existingPaths = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "/photos/2024-06-12 - Trip A",
+            "/photos/2024-06-12 - Trip A (1)"
+        };
+
+        var result = sut.ResolveAvailableDestination("/photos/2024-06-12 - Trip A", existingPaths.Contains);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(3, result.Attempts);
+        Assert.Equal("/photos/2024-06-12 - Trip A (2)", result.ResolvedDestinationPath);
+        Assert.False(result.ShouldAbortPlanExecution);
+        Assert.Null(result.Failure);
+        Assert.Null(result.SuggestedExitCode);
+    }
+
+    [Fact]
+    public void ResolveAvailableDestination_WhenRetryLimitIsExceeded_ReturnsAbortFailureAndExitCodeFive()
+    {
+        var sut = new ConflictRetryPolicy();
+
+        var result = sut.ResolveAvailableDestination("/photos/2024-06-12 - Trip A", _ => true);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(11, result.Attempts);
+        Assert.Null(result.ResolvedDestinationPath);
+        Assert.True(result.ShouldAbortPlanExecution);
+        Assert.Equal(ConflictRetryFailure.RetryLimitExceeded, result.Failure);
+        Assert.Equal(5, result.SuggestedExitCode);
+    }
+
+    [Fact]
+    public void ResolveAvailableDestination_NullExistenceCheck_ThrowsArgumentNullException()
+    {
+        var sut = new ConflictRetryPolicy();
+
+        Assert.Throws<ArgumentNullException>(() => sut.ResolveAvailableDestination("/photos/Trip A", null!));
+    }
+}


### PR DESCRIPTION
Closes #8

This change completes slice 160 by adding the core conflict retry policy that generates deterministic destination candidates and enforces the configured retry limit. Before this, the project had naming and date-range helpers but no reusable policy for handling destination collisions in a way that matched the v1 execution contract.

The user-visible effect is that plan execution can now attempt the planned destination first, then retry with ` (1)` through ` (10)` suffixes in a deterministic order. When no destination is available after the retry limit, the policy returns a structured abort result that carries the retry-limit failure and the exit-code hint required by the contract.

The root cause of the missing behavior was that adaptive conflict handling had not yet been isolated into a core service. This PR adds a small execution-focused policy, a structured resolution model, and targeted tests for suffix ordering, first-available resolution, retry-limit abort behavior, and guard clauses.

Validation was run locally with `dotnet build Renamer.sln` and `dotnet test Renamer.sln --filter "FullyQualifiedName~ConflictRetry"`, both of which passed.
