### PR TITLE
[codex] 170 plan json writer

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -21,7 +21,7 @@
 - [x] 140 Folder date range (`docs/specs/140-folder-date-range.md`)
 - [x] 150 Name generation (`docs/specs/150-name-generation.md`)
 - [x] 160 Conflict retry policy (`docs/specs/160-conflict-retry-policy.md`)
-- [ ] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)
+- [x] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)
 - [ ] 180 Apply engine (`docs/specs/180-apply-engine.md`)
 - [ ] 190 Report JSON writer (`docs/specs/190-report-json-writer.md`)
 - [ ] 200 CLI plan command (`docs/specs/200-cli-plan-command.md`)

--- a/src/Renamer.Core/Serialization/IPlanSerializer.cs
+++ b/src/Renamer.Core/Serialization/IPlanSerializer.cs
@@ -1,0 +1,8 @@
+using Renamer.Core.Contracts;
+
+namespace Renamer.Core.Serialization;
+
+public interface IPlanSerializer
+{
+    void Write(string outputPath, RenamePlan plan);
+}

--- a/src/Renamer.Core/Serialization/PlanSerializer.cs
+++ b/src/Renamer.Core/Serialization/PlanSerializer.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Renamer.Core.Contracts;
+
+namespace Renamer.Core.Serialization;
+
+public sealed class PlanSerializer : IPlanSerializer
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public void Write(string outputPath, RenamePlan plan)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+        ArgumentNullException.ThrowIfNull(plan);
+
+        ValidatePlan(plan);
+
+        var directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(plan, SerializerOptions);
+        File.WriteAllText(outputPath, json);
+    }
+
+    private static void ValidatePlan(RenamePlan plan)
+    {
+        if (plan.Operations.Count != plan.Summary.OperationCount)
+        {
+            throw new InvalidOperationException(
+                $"Invalid plan invariant: operations count '{plan.Operations.Count}' does not match summary.operationCount '{plan.Summary.OperationCount}'.");
+        }
+    }
+}

--- a/src/Renamer.Tests/Core/PlanSerializerTests.cs
+++ b/src/Renamer.Tests/Core/PlanSerializerTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using Renamer.Core.Contracts;
+using Renamer.Core.Serialization;
+
+namespace Renamer.Tests.Core;
+
+public sealed class PlanSerializerTests
+{
+    [Fact]
+    public void Write_CreatesExpectedPlanJsonShape()
+    {
+        var serializer = new PlanSerializer();
+        var outputPath = Path.Combine(Path.GetTempPath(), $"rename-plan-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var plan = CreatePlan();
+
+            serializer.Write(outputPath, plan);
+
+            var json = File.ReadAllText(outputPath);
+            using var document = JsonDocument.Parse(json);
+
+            var root = document.RootElement;
+            Assert.Equal("1.0", root.GetProperty("schemaVersion").GetString());
+            Assert.Equal(plan.PlanId, root.GetProperty("planId").GetString());
+            Assert.Equal(plan.CreatedAtUtc, root.GetProperty("createdAtUtc").GetString());
+            Assert.Equal(plan.RootPath, root.GetProperty("rootPath").GetString());
+
+            var operations = root.GetProperty("operations");
+            Assert.Equal(JsonValueKind.Array, operations.ValueKind);
+            Assert.Single(operations.EnumerateArray());
+
+            var operation = operations[0];
+            Assert.Equal(plan.Operations[0].OpId, operation.GetProperty("opId").GetString());
+            Assert.Equal(plan.Operations[0].SourcePath, operation.GetProperty("sourcePath").GetString());
+            Assert.Equal(plan.Operations[0].PlannedDestinationPath, operation.GetProperty("plannedDestinationPath").GetString());
+
+            var reason = operation.GetProperty("reason");
+            Assert.Equal(plan.Operations[0].Reason.StartDate, reason.GetProperty("startDate").GetString());
+            Assert.Equal(plan.Operations[0].Reason.EndDate, reason.GetProperty("endDate").GetString());
+            Assert.Equal(plan.Operations[0].Reason.FilesConsidered, reason.GetProperty("filesConsidered").GetInt32());
+            Assert.Equal(plan.Operations[0].Reason.FilesSkippedMissingExif, reason.GetProperty("filesSkippedMissingExif").GetInt32());
+
+            var summary = root.GetProperty("summary");
+            Assert.Equal(plan.Summary.OperationCount, summary.GetProperty("operationCount").GetInt32());
+            Assert.Equal(plan.Summary.Warnings, summary.GetProperty("warnings").GetInt32());
+
+            Assert.Equal(
+                summary.GetProperty("operationCount").GetInt32(),
+                operations.GetArrayLength());
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Write_WhenOutputExists_OverwritesFile()
+    {
+        var serializer = new PlanSerializer();
+        var outputPath = Path.Combine(Path.GetTempPath(), $"rename-plan-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            File.WriteAllText(outputPath, "{\"stale\":true}");
+            var plan = CreatePlan();
+
+            serializer.Write(outputPath, plan);
+
+            var json = File.ReadAllText(outputPath);
+            Assert.DoesNotContain("stale", json);
+            Assert.Contains("\"schemaVersion\": \"1.0\"", json);
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Write_WhenOperationCountInvariantIsBroken_Throws()
+    {
+        var serializer = new PlanSerializer();
+        var outputPath = Path.Combine(Path.GetTempPath(), $"rename-plan-{Guid.NewGuid():N}.json");
+        var plan = CreatePlan();
+        plan = new RenamePlan
+        {
+            SchemaVersion = plan.SchemaVersion,
+            PlanId = plan.PlanId,
+            CreatedAtUtc = plan.CreatedAtUtc,
+            RootPath = plan.RootPath,
+            Operations = plan.Operations,
+            Summary = new RenamePlanSummary
+            {
+                OperationCount = 2,
+                Warnings = plan.Summary.Warnings
+            }
+        };
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => serializer.Write(outputPath, plan));
+            Assert.Contains("summary.operationCount", exception.Message);
+            Assert.False(File.Exists(outputPath));
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    private static RenamePlan CreatePlan()
+    {
+        return new RenamePlan
+        {
+            SchemaVersion = "1.0",
+            PlanId = "d609111f-4fbb-4de3-8d6c-faf102a6fdb0",
+            CreatedAtUtc = "2026-03-01T16:10:00Z",
+            RootPath = "/photos",
+            Operations =
+            [
+                new RenamePlanOperation
+                {
+                    OpId = "7c730a84-4b07-4f56-8758-9906cf488e6b",
+                    SourcePath = "/photos/Trip A",
+                    PlannedDestinationPath = "/photos/2024-06-12 - 2024-06-14 - Trip A",
+                    Reason = new RenamePlanReason
+                    {
+                        StartDate = "2024-06-12",
+                        EndDate = "2024-06-14",
+                        FilesConsidered = 120,
+                        FilesSkippedMissingExif = 3
+                    }
+                }
+            ],
+            Summary = new RenamePlanSummary
+            {
+                OperationCount = 1,
+                Warnings = 3
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #9

This change completes slice 170 by adding the core plan serializer that writes the canonical `rename-plan.json` artifact from the existing plan contract models. Before this, the project had the plan data models and the supporting EXIF, date-range, naming, and conflict-policy pieces, but no writer for the planning artifact that later CLI and apply slices can consume.

The user-visible effect is that the core can now persist a plan artifact with the required v1 schema fields, stable camelCase JSON output, and overwrite semantics for an existing destination file. The implementation stays in `Renamer.Core` behind an `IPlanSerializer` abstraction so the upcoming CLI slice can compose it cleanly without moving serialization concerns into the wrapper layer.

The root cause of the missing behavior was that serialization had not yet been isolated into a dedicated core service. This PR adds the serializer contract and implementation, covers required field shape and summary invariants in tests, and verifies existing output files are overwritten by default.

Validation for this slice was covered by the targeted plan-serializer test scope included on the branch.
