### PR TITLE
[codex] 180 apply engine

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -22,7 +22,7 @@
 - [x] 150 Name generation (`docs/specs/150-name-generation.md`)
 - [x] 160 Conflict retry policy (`docs/specs/160-conflict-retry-policy.md`)
 - [x] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)
-- [ ] 180 Apply engine (`docs/specs/180-apply-engine.md`)
+- [x] 180 Apply engine (`docs/specs/180-apply-engine.md`)
 - [ ] 190 Report JSON writer (`docs/specs/190-report-json-writer.md`)
 - [ ] 200 CLI plan command (`docs/specs/200-cli-plan-command.md`)
 - [ ] 210 CLI apply command (`docs/specs/210-cli-apply-command.md`)

--- a/src/Renamer.Core/Execution/ApplyEngine.cs
+++ b/src/Renamer.Core/Execution/ApplyEngine.cs
@@ -1,0 +1,121 @@
+using Renamer.Core.Contracts;
+using Renamer.Core.IO;
+using Renamer.Core.Time;
+
+namespace Renamer.Core.Execution;
+
+public sealed class ApplyEngine : IApplyEngine
+{
+    private const string SchemaVersion = "1.0";
+    private const string SuccessStatus = "success";
+    private const string FailedStatus = "failed";
+
+    private readonly IClock clock;
+    private readonly IDirectoryMover directoryMover;
+    private readonly IConflictRetryPolicy conflictRetryPolicy;
+
+    public ApplyEngine()
+        : this(new ConflictRetryPolicy(), new DirectoryMover(), new SystemClock())
+    {
+    }
+
+    public ApplyEngine(IConflictRetryPolicy conflictRetryPolicy, IDirectoryMover directoryMover, IClock clock)
+    {
+        this.conflictRetryPolicy = conflictRetryPolicy ?? throw new ArgumentNullException(nameof(conflictRetryPolicy));
+        this.directoryMover = directoryMover ?? throw new ArgumentNullException(nameof(directoryMover));
+        this.clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public RenameReport Execute(RenamePlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var startedAtUtc = clock.UtcNow;
+        var results = new List<RenameReportResult>();
+
+        foreach (var operation in plan.Operations)
+        {
+            var result = ExecuteOperation(operation);
+            results.Add(result);
+
+            if (result.Status == FailedStatus)
+            {
+                break;
+            }
+        }
+
+        var finishedAtUtc = clock.UtcNow;
+
+        return new RenameReport
+        {
+            SchemaVersion = SchemaVersion,
+            PlanId = plan.PlanId,
+            StartedAtUtc = FormatUtc(startedAtUtc),
+            FinishedAtUtc = FormatUtc(finishedAtUtc),
+            Results = results,
+            Summary = new RenameReportSummary
+            {
+                Success = results.Count(result => result.Status == SuccessStatus),
+                Failed = results.Count(result => result.Status == FailedStatus),
+                Skipped = 0,
+                Drifted = results.Count(result =>
+                    result.Status == SuccessStatus &&
+                    !string.Equals(result.PlannedDestinationPath, result.ActualDestinationPath, StringComparison.Ordinal))
+            }
+        };
+    }
+
+    private RenameReportResult ExecuteOperation(RenamePlanOperation operation)
+    {
+        var candidatePaths = conflictRetryPolicy.GetCandidatePaths(operation.PlannedDestinationPath);
+
+        for (var index = 0; index < candidatePaths.Count; index++)
+        {
+            var candidatePath = candidatePaths[index];
+            if (directoryMover.Exists(candidatePath))
+            {
+                continue;
+            }
+
+            directoryMover.Move(operation.SourcePath, candidatePath);
+
+            return new RenameReportResult
+            {
+                OpId = operation.OpId,
+                SourcePath = operation.SourcePath,
+                PlannedDestinationPath = operation.PlannedDestinationPath,
+                ActualDestinationPath = candidatePath,
+                Status = SuccessStatus,
+                Attempts = index + 1,
+                Warnings = BuildWarnings(operation.PlannedDestinationPath, candidatePath),
+                Error = null
+            };
+        }
+
+        return new RenameReportResult
+        {
+            OpId = operation.OpId,
+            SourcePath = operation.SourcePath,
+            PlannedDestinationPath = operation.PlannedDestinationPath,
+            ActualDestinationPath = null,
+            Status = FailedStatus,
+            Attempts = candidatePaths.Count,
+            Warnings = [],
+            Error = $"Destination conflict unresolved after {ConflictRetryPolicy.MaxSuffixRetries} suffix retries."
+        };
+    }
+
+    private static string FormatUtc(DateTimeOffset timestamp) =>
+        timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+    private static IReadOnlyList<string> BuildWarnings(string plannedDestinationPath, string actualDestinationPath)
+    {
+        if (string.Equals(plannedDestinationPath, actualDestinationPath, StringComparison.Ordinal))
+        {
+            return [];
+        }
+
+        var suffix = actualDestinationPath[plannedDestinationPath.Length..];
+        return [$"Destination conflict; applied suffix{suffix}."];
+    }
+}

--- a/src/Renamer.Core/Execution/IApplyEngine.cs
+++ b/src/Renamer.Core/Execution/IApplyEngine.cs
@@ -1,0 +1,8 @@
+using Renamer.Core.Contracts;
+
+namespace Renamer.Core.Execution;
+
+public interface IApplyEngine
+{
+    RenameReport Execute(RenamePlan plan);
+}

--- a/src/Renamer.Core/IO/DirectoryMover.cs
+++ b/src/Renamer.Core/IO/DirectoryMover.cs
@@ -1,0 +1,19 @@
+namespace Renamer.Core.IO;
+
+public sealed class DirectoryMover : IDirectoryMover
+{
+    public bool Exists(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        return Directory.Exists(path);
+    }
+
+    public void Move(string sourcePath, string destinationPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+
+        Directory.Move(sourcePath, destinationPath);
+    }
+}

--- a/src/Renamer.Core/IO/IDirectoryMover.cs
+++ b/src/Renamer.Core/IO/IDirectoryMover.cs
@@ -1,0 +1,8 @@
+namespace Renamer.Core.IO;
+
+public interface IDirectoryMover
+{
+    bool Exists(string path);
+
+    void Move(string sourcePath, string destinationPath);
+}

--- a/src/Renamer.Core/Time/IClock.cs
+++ b/src/Renamer.Core/Time/IClock.cs
@@ -1,0 +1,6 @@
+namespace Renamer.Core.Time;
+
+public interface IClock
+{
+    DateTimeOffset UtcNow { get; }
+}

--- a/src/Renamer.Core/Time/SystemClock.cs
+++ b/src/Renamer.Core/Time/SystemClock.cs
@@ -1,0 +1,6 @@
+namespace Renamer.Core.Time;
+
+public sealed class SystemClock : IClock
+{
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/src/Renamer.Tests/Core/ApplyEngineTests.cs
+++ b/src/Renamer.Tests/Core/ApplyEngineTests.cs
@@ -1,0 +1,176 @@
+using Renamer.Core.Contracts;
+using Renamer.Core.Execution;
+using Renamer.Core.IO;
+using Renamer.Core.Time;
+
+namespace Renamer.Tests.Core;
+
+public sealed class ApplyEngineTests
+{
+    [Fact]
+    public void Execute_WhenPlannedDestinationIsAvailable_RenamesSuccessfullyOnFirstAttempt()
+    {
+        var directoryMover = new FakeDirectoryMover();
+        var clock = new FakeClock(
+            new DateTimeOffset(2026, 3, 11, 10, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 11, 10, 0, 1, TimeSpan.Zero));
+        var sut = new ApplyEngine(new ConflictRetryPolicy(), directoryMover, clock);
+        var plan = CreatePlan();
+
+        var report = sut.Execute(plan);
+
+        var result = Assert.Single(report.Results);
+        Assert.Equal("success", result.Status);
+        Assert.Equal(1, result.Attempts);
+        Assert.Equal(plan.Operations[0].PlannedDestinationPath, result.ActualDestinationPath);
+        Assert.Empty(result.Warnings);
+        Assert.Null(result.Error);
+        Assert.Equal(plan.Operations[0].SourcePath, directoryMover.MoveCalls.Single().SourcePath);
+        Assert.Equal(plan.Operations[0].PlannedDestinationPath, directoryMover.MoveCalls.Single().DestinationPath);
+        Assert.Equal(1, report.Summary.Success);
+        Assert.Equal(0, report.Summary.Failed);
+        Assert.Equal(0, report.Summary.Drifted);
+        Assert.Equal("2026-03-11T10:00:00Z", report.StartedAtUtc);
+        Assert.Equal("2026-03-11T10:00:01Z", report.FinishedAtUtc);
+    }
+
+    [Fact]
+    public void Execute_WhenConflictsExist_RetriesUntilFirstAvailableSuffix()
+    {
+        var directoryMover = new FakeDirectoryMover(
+            existingPaths:
+            [
+                "/photos/2024-06-12 - 2024-06-14 - Trip A",
+                "/photos/2024-06-12 - 2024-06-14 - Trip A (1)"
+            ]);
+        var clock = new FakeClock(
+            new DateTimeOffset(2026, 3, 11, 10, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 11, 10, 0, 1, TimeSpan.Zero));
+        var sut = new ApplyEngine(new ConflictRetryPolicy(), directoryMover, clock);
+        var plan = CreatePlan();
+
+        var report = sut.Execute(plan);
+
+        var result = Assert.Single(report.Results);
+        Assert.Equal("success", result.Status);
+        Assert.Equal(3, result.Attempts);
+        Assert.Equal("/photos/2024-06-12 - 2024-06-14 - Trip A (2)", result.ActualDestinationPath);
+        Assert.Equal(["Destination conflict; applied suffix (2)."], result.Warnings);
+        Assert.Equal(1, report.Summary.Success);
+        Assert.Equal(1, report.Summary.Drifted);
+    }
+
+    [Fact]
+    public void Execute_WhenRetryLimitIsExceeded_FailsCurrentOperationAndAbortsPlan()
+    {
+        var existingPaths = new List<string> { "/photos/2024-06-12 - 2024-06-14 - Trip A" };
+        for (var suffix = 1; suffix <= 10; suffix++)
+        {
+            existingPaths.Add($"/photos/2024-06-12 - 2024-06-14 - Trip A ({suffix})");
+        }
+
+        var directoryMover = new FakeDirectoryMover(existingPaths);
+        var clock = new FakeClock(
+            new DateTimeOffset(2026, 3, 11, 10, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 11, 10, 0, 1, TimeSpan.Zero));
+        var sut = new ApplyEngine(new ConflictRetryPolicy(), directoryMover, clock);
+        var plan = CreatePlanWithTwoOperations();
+
+        var report = sut.Execute(plan);
+
+        var result = Assert.Single(report.Results);
+        Assert.Equal("failed", result.Status);
+        Assert.Equal(11, result.Attempts);
+        Assert.Null(result.ActualDestinationPath);
+        Assert.Empty(result.Warnings);
+        Assert.Contains("10 suffix retries", result.Error);
+        Assert.Empty(directoryMover.MoveCalls);
+        Assert.Equal(0, report.Summary.Success);
+        Assert.Equal(1, report.Summary.Failed);
+        Assert.Equal(0, report.Summary.Drifted);
+    }
+
+    private static RenamePlan CreatePlan() =>
+        new()
+        {
+            SchemaVersion = "1.0",
+            PlanId = "d609111f-4fbb-4de3-8d6c-faf102a6fdb0",
+            CreatedAtUtc = "2026-03-01T16:10:00Z",
+            RootPath = "/photos",
+            Operations =
+            [
+                CreateOperation(
+                    "7c730a84-4b07-4f56-8758-9906cf488e6b",
+                    "/photos/Trip A",
+                    "/photos/2024-06-12 - 2024-06-14 - Trip A")
+            ],
+            Summary = new RenamePlanSummary
+            {
+                OperationCount = 1,
+                Warnings = 0
+            }
+        };
+
+    private static RenamePlan CreatePlanWithTwoOperations() =>
+        new()
+        {
+            SchemaVersion = "1.0",
+            PlanId = "d609111f-4fbb-4de3-8d6c-faf102a6fdb0",
+            CreatedAtUtc = "2026-03-01T16:10:00Z",
+            RootPath = "/photos",
+            Operations =
+            [
+                CreateOperation(
+                    "7c730a84-4b07-4f56-8758-9906cf488e6b",
+                    "/photos/Trip A",
+                    "/photos/2024-06-12 - 2024-06-14 - Trip A"),
+                CreateOperation(
+                    "0e46e38f-9801-42ac-a2cf-8d184fa6a5f9",
+                    "/photos/Trip B",
+                    "/photos/2024-06-15 - Trip B")
+            ],
+            Summary = new RenamePlanSummary
+            {
+                OperationCount = 2,
+                Warnings = 0
+            }
+        };
+
+    private static RenamePlanOperation CreateOperation(string opId, string sourcePath, string plannedDestinationPath) =>
+        new()
+        {
+            OpId = opId,
+            SourcePath = sourcePath,
+            PlannedDestinationPath = plannedDestinationPath,
+            Reason = new RenamePlanReason
+            {
+                StartDate = "2024-06-12",
+                EndDate = "2024-06-14",
+                FilesConsidered = 12,
+                FilesSkippedMissingExif = 0
+            }
+        };
+
+    private sealed class FakeDirectoryMover(IEnumerable<string>? existingPaths = null) : IDirectoryMover
+    {
+        private readonly HashSet<string> existing = new(existingPaths ?? [], StringComparer.Ordinal);
+
+        public List<(string SourcePath, string DestinationPath)> MoveCalls { get; } = [];
+
+        public bool Exists(string path) => existing.Contains(path);
+
+        public void Move(string sourcePath, string destinationPath)
+        {
+            MoveCalls.Add((sourcePath, destinationPath));
+            existing.Remove(sourcePath);
+            existing.Add(destinationPath);
+        }
+    }
+
+    private sealed class FakeClock(params DateTimeOffset[] values) : IClock
+    {
+        private readonly Queue<DateTimeOffset> values = new(values);
+
+        public DateTimeOffset UtcNow => values.Dequeue();
+    }
+}


### PR DESCRIPTION
Closes #10

This change completes slice 180 by adding the core apply engine that executes rename operations from a plan and produces the in-memory report model required by later reporting and CLI slices. Before this, the project could build rename plans, generate deterministic folder names, and calculate conflict retry candidates, but it still lacked the execution layer that applies planned renames and records success, retry, drift, and abort outcomes.

The user-visible effect is that the core can now attempt the planned destination first, retry with the deterministic suffix policy when conflicts exist, and abort plan execution when the retry limit is exhausted. The engine returns a full `RenameReport` shape with timestamps, attempts, warnings, failure details, and summary counters, which gives the next report-serialization and CLI slices the contract they need.

The root cause of the missing behavior was that plan execution, filesystem movement, and execution timing had not yet been isolated behind a dedicated core service. This PR adds `IApplyEngine` and `ApplyEngine`, plus small IO and clock abstractions to keep the behavior testable without tying unit tests to the real filesystem or wall-clock time.

Validation was run locally with `dotnet build Renamer.sln` and `dotnet test Renamer.sln --filter "FullyQualifiedName~ApplyEngine"`, both of which passed.
