### PR TITLE
[codex] 190 report json writer

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -23,7 +23,7 @@
 - [x] 160 Conflict retry policy (`docs/specs/160-conflict-retry-policy.md`)
 - [x] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)
 - [x] 180 Apply engine (`docs/specs/180-apply-engine.md`)
-- [ ] 190 Report JSON writer (`docs/specs/190-report-json-writer.md`)
+- [x] 190 Report JSON writer (`docs/specs/190-report-json-writer.md`)
 - [ ] 200 CLI plan command (`docs/specs/200-cli-plan-command.md`)
 - [ ] 210 CLI apply command (`docs/specs/210-cli-apply-command.md`)
 - [ ] 220 Serilog UI bootstrap (`docs/specs/220-serilog-ui-bootstrap.md`)

--- a/src/Renamer.Core/Serialization/IReportSerializer.cs
+++ b/src/Renamer.Core/Serialization/IReportSerializer.cs
@@ -1,0 +1,8 @@
+using Renamer.Core.Contracts;
+
+namespace Renamer.Core.Serialization;
+
+public interface IReportSerializer
+{
+    void Write(string outputPath, RenameReport report);
+}

--- a/src/Renamer.Core/Serialization/ReportSerializer.cs
+++ b/src/Renamer.Core/Serialization/ReportSerializer.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using Renamer.Core.Contracts;
+
+namespace Renamer.Core.Serialization;
+
+public sealed class ReportSerializer : IReportSerializer
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public void Write(string outputPath, RenameReport report)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+        ArgumentNullException.ThrowIfNull(report);
+
+        var normalizedReport = NormalizeReport(report);
+
+        var directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(normalizedReport, SerializerOptions);
+        File.WriteAllText(outputPath, json);
+    }
+
+    private static RenameReport NormalizeReport(RenameReport report)
+    {
+        var summary = new RenameReportSummary
+        {
+            Success = report.Results.Count(result => result.Status == "success"),
+            Failed = report.Results.Count(result => result.Status == "failed"),
+            Skipped = report.Results.Count(result => result.Status == "skipped"),
+            Drifted = report.Results.Count(result =>
+                result.Status == "success" &&
+                !string.Equals(result.PlannedDestinationPath, result.ActualDestinationPath, StringComparison.Ordinal))
+        };
+
+        ValidateReport(report, summary);
+
+        return new RenameReport
+        {
+            SchemaVersion = report.SchemaVersion,
+            PlanId = report.PlanId,
+            StartedAtUtc = report.StartedAtUtc,
+            FinishedAtUtc = report.FinishedAtUtc,
+            Results = report.Results,
+            Summary = summary
+        };
+    }
+
+    private static void ValidateReport(RenameReport report, RenameReportSummary summary)
+    {
+        if (report.Results.Any(result => result.Attempts < 1))
+        {
+            throw new InvalidOperationException("Invalid report invariant: each result.attempts must be at least 1.");
+        }
+
+        var totalCount = summary.Success + summary.Failed + summary.Skipped;
+        if (totalCount != report.Results.Count)
+        {
+            throw new InvalidOperationException(
+                $"Invalid report invariant: summary counts '{totalCount}' do not match results count '{report.Results.Count}'.");
+        }
+    }
+}

--- a/src/Renamer.Tests/Core/ReportSerializerTests.cs
+++ b/src/Renamer.Tests/Core/ReportSerializerTests.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using Renamer.Core.Contracts;
+using Renamer.Core.Serialization;
+
+namespace Renamer.Tests.Core;
+
+public sealed class ReportSerializerTests
+{
+    [Fact]
+    public void Write_CreatesExpectedReportJsonShapeIncludingNullableFields()
+    {
+        var serializer = new ReportSerializer();
+        var outputPath = Path.Combine(Path.GetTempPath(), $"rename-report-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var report = CreateReport();
+
+            serializer.Write(outputPath, report);
+
+            var json = File.ReadAllText(outputPath);
+            using var document = JsonDocument.Parse(json);
+
+            var root = document.RootElement;
+            Assert.Equal("1.0", root.GetProperty("schemaVersion").GetString());
+            Assert.Equal(report.PlanId, root.GetProperty("planId").GetString());
+            Assert.Equal(report.StartedAtUtc, root.GetProperty("startedAtUtc").GetString());
+            Assert.Equal(report.FinishedAtUtc, root.GetProperty("finishedAtUtc").GetString());
+
+            var results = root.GetProperty("results");
+            Assert.Equal(JsonValueKind.Array, results.ValueKind);
+            Assert.Equal(3, results.GetArrayLength());
+
+            var failedResult = results[1];
+            Assert.Equal("failed", failedResult.GetProperty("status").GetString());
+            Assert.Equal(JsonValueKind.Null, failedResult.GetProperty("actualDestinationPath").ValueKind);
+            Assert.Equal(JsonValueKind.Null, failedResult.GetProperty("error").ValueKind);
+
+            var summary = root.GetProperty("summary");
+            Assert.Equal(1, summary.GetProperty("success").GetInt32());
+            Assert.Equal(1, summary.GetProperty("failed").GetInt32());
+            Assert.Equal(1, summary.GetProperty("skipped").GetInt32());
+            Assert.Equal(1, summary.GetProperty("drifted").GetInt32());
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Write_WhenOutputExists_OverwritesFile()
+    {
+        var serializer = new ReportSerializer();
+        var outputPath = Path.Combine(Path.GetTempPath(), $"rename-report-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            File.WriteAllText(outputPath, "{\"stale\":true}");
+
+            serializer.Write(outputPath, CreateReport());
+
+            var json = File.ReadAllText(outputPath);
+            Assert.DoesNotContain("stale", json);
+            Assert.Contains("\"schemaVersion\": \"1.0\"", json);
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Write_WhenSummaryInputIsWrong_RecomputesSummaryFromResults()
+    {
+        var serializer = new ReportSerializer();
+        var outputPath = Path.Combine(Path.GetTempPath(), $"rename-report-{Guid.NewGuid():N}.json");
+        var report = CreateReport();
+        report = new RenameReport
+        {
+            SchemaVersion = report.SchemaVersion,
+            PlanId = report.PlanId,
+            StartedAtUtc = report.StartedAtUtc,
+            FinishedAtUtc = report.FinishedAtUtc,
+            Results = report.Results,
+            Summary = new RenameReportSummary
+            {
+                Success = 99,
+                Failed = 0,
+                Skipped = 0,
+                Drifted = 99
+            }
+        };
+
+        try
+        {
+            serializer.Write(outputPath, report);
+
+            using var document = JsonDocument.Parse(File.ReadAllText(outputPath));
+            var summary = document.RootElement.GetProperty("summary");
+            Assert.Equal(1, summary.GetProperty("success").GetInt32());
+            Assert.Equal(1, summary.GetProperty("failed").GetInt32());
+            Assert.Equal(1, summary.GetProperty("skipped").GetInt32());
+            Assert.Equal(1, summary.GetProperty("drifted").GetInt32());
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Write_WhenAttemptsInvariantIsBroken_Throws()
+    {
+        var serializer = new ReportSerializer();
+        var outputPath = Path.Combine(Path.GetTempPath(), $"rename-report-{Guid.NewGuid():N}.json");
+        var report = CreateReport();
+        report = new RenameReport
+        {
+            SchemaVersion = report.SchemaVersion,
+            PlanId = report.PlanId,
+            StartedAtUtc = report.StartedAtUtc,
+            FinishedAtUtc = report.FinishedAtUtc,
+            Results =
+            [
+                new RenameReportResult
+                {
+                    OpId = "broken",
+                    SourcePath = "/photos/Broken",
+                    PlannedDestinationPath = "/photos/Broken",
+                    ActualDestinationPath = null,
+                    Status = "failed",
+                    Attempts = 0,
+                    Warnings = [],
+                    Error = "bad"
+                }
+            ],
+            Summary = report.Summary
+        };
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => serializer.Write(outputPath, report));
+            Assert.Contains("result.attempts", exception.Message);
+            Assert.False(File.Exists(outputPath));
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    private static RenameReport CreateReport() =>
+        new()
+        {
+            SchemaVersion = "1.0",
+            PlanId = "d609111f-4fbb-4de3-8d6c-faf102a6fdb0",
+            StartedAtUtc = "2026-03-01T16:11:00Z",
+            FinishedAtUtc = "2026-03-01T16:11:01Z",
+            Results =
+            [
+                new RenameReportResult
+                {
+                    OpId = "success-1",
+                    SourcePath = "/photos/Trip A",
+                    PlannedDestinationPath = "/photos/2024-06-12 - 2024-06-14 - Trip A",
+                    ActualDestinationPath = "/photos/2024-06-12 - 2024-06-14 - Trip A (1)",
+                    Status = "success",
+                    Attempts = 2,
+                    Warnings = ["Destination conflict; applied suffix (1)."],
+                    Error = null
+                },
+                new RenameReportResult
+                {
+                    OpId = "failed-1",
+                    SourcePath = "/photos/Trip B",
+                    PlannedDestinationPath = "/photos/2024-06-15 - Trip B",
+                    ActualDestinationPath = null,
+                    Status = "failed",
+                    Attempts = 1,
+                    Warnings = [],
+                    Error = null
+                },
+                new RenameReportResult
+                {
+                    OpId = "skipped-1",
+                    SourcePath = "/photos/Trip C",
+                    PlannedDestinationPath = "/photos/2024-06-16 - Trip C",
+                    ActualDestinationPath = null,
+                    Status = "skipped",
+                    Attempts = 1,
+                    Warnings = ["Skipped for test coverage."],
+                    Error = "Not applied."
+                }
+            ],
+            Summary = new RenameReportSummary
+            {
+                Success = 0,
+                Failed = 0,
+                Skipped = 0,
+                Drifted = 0
+            }
+        };
+}


### PR DESCRIPTION
Closes #11

This change completes slice 190 by adding the core report serializer that persists the canonical `rename-report.json` artifact from the in-memory execution report model. Before this, the project could execute rename plans and build `RenameReport` results in memory, but it still lacked the writer needed to persist those outcomes for the CLI and UI flows.

The user-visible effect is that the core can now write report artifacts with the required top-level fields, per-result fields including nullable `actualDestinationPath` and `error`, and summary counters that reflect the actual result set. The serializer recomputes summary counts, including `drifted`, from `results` before writing so the output remains aligned with the v1 schema even if the incoming summary data is stale or incorrect.

The root cause of the missing behavior was that report persistence had not yet been isolated into a dedicated core service. This PR adds `IReportSerializer` and `ReportSerializer`, keeps serialization behavior consistent with the existing plan serializer, and adds targeted tests for schema shape, overwrite behavior, summary recomputation, and invalid `attempts` handling.

Validation was run locally with `dotnet build Renamer.sln` and `dotnet test Renamer.sln --filter "FullyQualifiedName~ReportSerializer"`, both of which passed.
