### PR TITLE
[codex] 200 cli plan command

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -24,7 +24,7 @@
 - [x] 170 Plan JSON writer (`docs/specs/170-plan-json-writer.md`)
 - [x] 180 Apply engine (`docs/specs/180-apply-engine.md`)
 - [x] 190 Report JSON writer (`docs/specs/190-report-json-writer.md`)
-- [ ] 200 CLI plan command (`docs/specs/200-cli-plan-command.md`)
+- [x] 200 CLI plan command (`docs/specs/200-cli-plan-command.md`)
 - [ ] 210 CLI apply command (`docs/specs/210-cli-apply-command.md`)
 - [ ] 220 Serilog UI bootstrap (`docs/specs/220-serilog-ui-bootstrap.md`)
 - [ ] 230 Desktop plan view (`docs/specs/230-maui-plan-view.md`)

--- a/src/Renamer.Cli/CliCommandDispatcher.cs
+++ b/src/Renamer.Cli/CliCommandDispatcher.cs
@@ -20,6 +20,8 @@ public sealed class CliCommandDispatcher(
                 logger.LogWarning("Unsupported CLI command {Command}.", parsedCommand.CommandText);
                 break;
             case CliCommandType.Plan:
+                logger.LogInformation("Accepted CLI command {Command}.", parsedCommand.CommandText);
+                break;
             case CliCommandType.Apply:
                 logger.LogInformation("Accepted CLI command {Command}. Command implementation is pending.", parsedCommand.CommandText);
                 break;

--- a/src/Renamer.Cli/Commands/CliCommand.cs
+++ b/src/Renamer.Cli/Commands/CliCommand.cs
@@ -3,4 +3,5 @@ namespace Renamer.Cli.Commands;
 public sealed record CliCommand(
     CliCommandType Type,
     string? CommandText,
-    CliCommandParseError ParseError = CliCommandParseError.None);
+    CliCommandParseError ParseError = CliCommandParseError.None,
+    IReadOnlyList<string>? Arguments = null);

--- a/src/Renamer.Cli/Commands/CliCommandHandler.cs
+++ b/src/Renamer.Cli/Commands/CliCommandHandler.cs
@@ -1,3 +1,6 @@
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
+
 namespace Renamer.Cli.Commands;
 
 public sealed class CliCommandHandler : ICliCommandHandler
@@ -11,15 +14,96 @@ public sealed class CliCommandHandler : ICliCommandHandler
         "  apply --plan <path> --out <path>"
     ];
 
+    private readonly IPlanBuilder planBuilder;
+    private readonly IPlanSerializer planSerializer;
+
+    public CliCommandHandler(IPlanBuilder planBuilder, IPlanSerializer planSerializer)
+    {
+        this.planBuilder = planBuilder ?? throw new ArgumentNullException(nameof(planBuilder));
+        this.planSerializer = planSerializer ?? throw new ArgumentNullException(nameof(planSerializer));
+    }
+
     public CommandResult Handle(CliCommand command)
     {
         return command.Type switch
         {
             CliCommandType.Help => new CommandResult(ProcessExitCode.Success, HelpLines),
-            CliCommandType.Plan => new CommandResult(ProcessExitCode.Success, []),
+            CliCommandType.Plan => HandlePlan(command),
             CliCommandType.Apply => new CommandResult(ProcessExitCode.Success, []),
             CliCommandType.Invalid => new CommandResult(ProcessExitCode.ValidationFailure, HelpLines),
             _ => new CommandResult(ProcessExitCode.UnexpectedRuntimeError, [])
         };
+    }
+
+    private CommandResult HandlePlan(CliCommand command)
+    {
+        var arguments = command.Arguments ?? [];
+        if (!TryGetOptionValue(arguments, "--root", out var rootPath) ||
+            !TryGetOptionValue(arguments, "--out", out var outputPath))
+        {
+            return new CommandResult(ProcessExitCode.ValidationFailure, HelpLines);
+        }
+
+        if (!Directory.Exists(rootPath))
+        {
+            return new CommandResult(ProcessExitCode.IoFailure, [$"Root path '{rootPath}' does not exist or is not a directory."]);
+        }
+
+        try
+        {
+            EnsureWritableOutputPath(outputPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new CommandResult(ProcessExitCode.IoFailure, [$"Output path '{outputPath}' is not writable: {ex.Message}"]);
+        }
+
+        try
+        {
+            var plan = planBuilder.Build(rootPath);
+            planSerializer.Write(outputPath, plan);
+            return new CommandResult(ProcessExitCode.Success, []);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new CommandResult(ProcessExitCode.IoFailure, [ex.Message]);
+        }
+        catch (Exception ex)
+        {
+            return new CommandResult(ProcessExitCode.UnexpectedRuntimeError, [ex.Message]);
+        }
+    }
+
+    private static bool TryGetOptionValue(IReadOnlyList<string> arguments, string optionName, out string value)
+    {
+        for (var index = 0; index < arguments.Count - 1; index++)
+        {
+            if (string.Equals(arguments[index], optionName, StringComparison.Ordinal))
+            {
+                value = arguments[index + 1];
+                return !string.IsNullOrWhiteSpace(value);
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static void EnsureWritableOutputPath(string outputPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+
+        var fullOutputPath = Path.GetFullPath(outputPath);
+        var directory = Path.GetDirectoryName(fullOutputPath);
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            directory = Directory.GetCurrentDirectory();
+        }
+
+        Directory.CreateDirectory(directory);
+
+        var probePath = Path.Combine(directory, $".renamer-write-test-{Guid.NewGuid():N}.tmp");
+        File.WriteAllText(probePath, string.Empty);
+        File.Delete(probePath);
     }
 }

--- a/src/Renamer.Cli/Commands/CliCommandParser.cs
+++ b/src/Renamer.Cli/Commands/CliCommandParser.cs
@@ -10,12 +10,13 @@ public static class CliCommandParser
         }
 
         var command = args[0].Trim().ToLowerInvariant();
+        var commandArguments = args.Skip(1).ToArray();
         return command switch
         {
-            "help" or "--help" or "-h" => new CliCommand(CliCommandType.Help, command),
-            "plan" => new CliCommand(CliCommandType.Plan, command),
-            "apply" => new CliCommand(CliCommandType.Apply, command),
-            _ => new CliCommand(CliCommandType.Invalid, command, CliCommandParseError.UnsupportedCommand)
+            "help" or "--help" or "-h" => new CliCommand(CliCommandType.Help, command, Arguments: commandArguments),
+            "plan" => new CliCommand(CliCommandType.Plan, command, Arguments: commandArguments),
+            "apply" => new CliCommand(CliCommandType.Apply, command, Arguments: commandArguments),
+            _ => new CliCommand(CliCommandType.Invalid, command, CliCommandParseError.UnsupportedCommand, commandArguments)
         };
     }
 }

--- a/src/Renamer.Cli/Program.cs
+++ b/src/Renamer.Cli/Program.cs
@@ -1,7 +1,11 @@
 using Renamer.Cli.Commands;
 using Renamer.Cli.Runtime;
+using Renamer.Core.Execution;
 using Renamer.Core.Exif;
 using Renamer.Core.Logging;
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
+using Renamer.Core.Time;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -79,9 +83,23 @@ public sealed class CliApplication(
         services.AddSingleton(runtimeEnvironment);
         services.AddSingleton(logPathProvider);
         services.AddSingleton(output);
-        services.AddSingleton(commandHandler ?? new CliCommandHandler());
+        services.AddSingleton<IClock, SystemClock>();
         services.AddSingleton(exifMetadataReader ?? new MetadataExtractorExifMetadataReader());
         services.AddSingleton<IExifService, ExifService>();
+        services.AddSingleton<IFolderDateRangeCalculator, FolderDateRangeCalculator>();
+        services.AddSingleton<IFolderNameGenerator, FolderNameGenerator>();
+        services.AddSingleton<IConflictRetryPolicy, ConflictRetryPolicy>();
+        services.AddSingleton<IPlanBuilder, PlanBuilder>();
+        services.AddSingleton<IPlanSerializer, PlanSerializer>();
+        if (commandHandler is not null)
+        {
+            services.AddSingleton(commandHandler);
+            services.AddSingleton<ICliCommandHandler>(commandHandler);
+        }
+        else
+        {
+            services.AddSingleton<ICliCommandHandler, CliCommandHandler>();
+        }
         services.AddSingleton<CliCommandDispatcher>();
         services.AddLogging(builder =>
         {

--- a/src/Renamer.Core/Planning/IPlanBuilder.cs
+++ b/src/Renamer.Core/Planning/IPlanBuilder.cs
@@ -1,0 +1,8 @@
+using Renamer.Core.Contracts;
+
+namespace Renamer.Core.Planning;
+
+public interface IPlanBuilder
+{
+    RenamePlan Build(string rootPath);
+}

--- a/src/Renamer.Core/Planning/PlanBuilder.cs
+++ b/src/Renamer.Core/Planning/PlanBuilder.cs
@@ -1,0 +1,130 @@
+using Renamer.Core.Contracts;
+using Renamer.Core.Execution;
+using Renamer.Core.Exif;
+using Renamer.Core.Time;
+
+namespace Renamer.Core.Planning;
+
+public sealed class PlanBuilder : IPlanBuilder
+{
+    private const string SchemaVersion = "1.0";
+
+    private readonly IClock clock;
+    private readonly IExifService exifService;
+    private readonly IFolderDateRangeCalculator folderDateRangeCalculator;
+    private readonly IFolderNameGenerator folderNameGenerator;
+    private readonly IConflictRetryPolicy conflictRetryPolicy;
+
+    public PlanBuilder(
+        IExifService exifService,
+        IFolderDateRangeCalculator folderDateRangeCalculator,
+        IFolderNameGenerator folderNameGenerator,
+        IConflictRetryPolicy conflictRetryPolicy,
+        IClock clock)
+    {
+        this.exifService = exifService ?? throw new ArgumentNullException(nameof(exifService));
+        this.folderDateRangeCalculator = folderDateRangeCalculator ?? throw new ArgumentNullException(nameof(folderDateRangeCalculator));
+        this.folderNameGenerator = folderNameGenerator ?? throw new ArgumentNullException(nameof(folderNameGenerator));
+        this.conflictRetryPolicy = conflictRetryPolicy ?? throw new ArgumentNullException(nameof(conflictRetryPolicy));
+        this.clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public RenamePlan Build(string rootPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootPath);
+
+        var fullRootPath = Path.GetFullPath(rootPath);
+        var operations = new List<RenamePlanOperation>();
+        var reservedDestinations = new HashSet<string>(StringComparer.Ordinal);
+        var warnings = 0;
+
+        foreach (var sourceDirectory in Directory.GetDirectories(fullRootPath).OrderBy(path => path, StringComparer.Ordinal))
+        {
+            var supportedFileResults = new List<ExifReadResult>();
+            var filesConsidered = 0;
+            var filesSkippedMissingExif = 0;
+
+            foreach (var filePath in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+            {
+                var exifResult = exifService.ReadCaptureDate(filePath);
+                if (!exifResult.IsSupportedFileType)
+                {
+                    continue;
+                }
+
+                filesConsidered++;
+                if (exifResult.ShouldIncrementMissingExifCount)
+                {
+                    filesSkippedMissingExif++;
+                    warnings++;
+                }
+
+                supportedFileResults.Add(exifResult);
+            }
+
+            var dateRange = folderDateRangeCalculator.Calculate(supportedFileResults);
+            if (!dateRange.IsPlannable || dateRange.StartDate is null || dateRange.EndDate is null)
+            {
+                continue;
+            }
+
+            var folderName = Path.GetFileName(sourceDirectory);
+            var plannedName = folderNameGenerator.Generate(folderName, dateRange.StartDate.Value, dateRange.EndDate.Value);
+            var parentDirectory = Directory.GetParent(sourceDirectory)?.FullName
+                ?? throw new InvalidOperationException($"Source directory '{sourceDirectory}' does not have a parent directory.");
+
+            var baseDestinationPath = Path.Combine(parentDirectory, plannedName);
+            var plannedDestinationPath = ResolvePlannedDestinationPath(baseDestinationPath, sourceDirectory, reservedDestinations);
+            reservedDestinations.Add(plannedDestinationPath);
+
+            operations.Add(new RenamePlanOperation
+            {
+                OpId = Guid.NewGuid().ToString(),
+                SourcePath = sourceDirectory,
+                PlannedDestinationPath = plannedDestinationPath,
+                Reason = new RenamePlanReason
+                {
+                    StartDate = dateRange.StartDate.Value.ToString("yyyy-MM-dd"),
+                    EndDate = dateRange.EndDate.Value.ToString("yyyy-MM-dd"),
+                    FilesConsidered = filesConsidered,
+                    FilesSkippedMissingExif = filesSkippedMissingExif
+                }
+            });
+        }
+
+        return new RenamePlan
+        {
+            SchemaVersion = SchemaVersion,
+            PlanId = Guid.NewGuid().ToString(),
+            CreatedAtUtc = clock.UtcNow.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"),
+            RootPath = fullRootPath,
+            Operations = operations,
+            Summary = new RenamePlanSummary
+            {
+                OperationCount = operations.Count,
+                Warnings = warnings
+            }
+        };
+    }
+
+    private string ResolvePlannedDestinationPath(string baseDestinationPath, string sourceDirectory, HashSet<string> reservedDestinations)
+    {
+        foreach (var candidatePath in conflictRetryPolicy.GetCandidatePaths(baseDestinationPath))
+        {
+            if (string.Equals(candidatePath, sourceDirectory, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (reservedDestinations.Contains(candidatePath) || Directory.Exists(candidatePath))
+            {
+                continue;
+            }
+
+            return candidatePath;
+        }
+
+        throw new InvalidOperationException(
+            $"Unable to determine a unique planned destination path for '{sourceDirectory}' after {ConflictRetryPolicy.MaxSuffixRetries} suffix retries.");
+    }
+}

--- a/src/Renamer.Tests/CLI/CliCommandDispatcherTests.cs
+++ b/src/Renamer.Tests/CLI/CliCommandDispatcherTests.cs
@@ -1,5 +1,8 @@
 using Renamer.Cli;
 using Renamer.Cli.Commands;
+using Renamer.Core.Contracts;
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Renamer.Tests.CLI;
@@ -10,7 +13,7 @@ public sealed class CliCommandDispatcherTests
     public void Dispatch_HelpCommand_PrintsAvailableCommandsAndReturnsSuccess()
     {
         using var writer = new StringWriter();
-        var dispatcher = new CliCommandDispatcher(writer, new CliCommandHandler(), NullLogger<CliCommandDispatcher>.Instance);
+        var dispatcher = new CliCommandDispatcher(writer, CreateHandler(), NullLogger<CliCommandDispatcher>.Instance);
 
         var exitCode = dispatcher.Dispatch(["help"]);
         var text = writer.ToString();
@@ -25,12 +28,25 @@ public sealed class CliCommandDispatcherTests
     public void Dispatch_UnsupportedCommand_PrintsHelpAndReturnsValidationCode()
     {
         using var writer = new StringWriter();
-        var dispatcher = new CliCommandDispatcher(writer, new CliCommandHandler(), NullLogger<CliCommandDispatcher>.Instance);
+        var dispatcher = new CliCommandDispatcher(writer, CreateHandler(), NullLogger<CliCommandDispatcher>.Instance);
 
         var exitCode = dispatcher.Dispatch(["wat"]);
         var text = writer.ToString();
 
         Assert.Equal((int)ProcessExitCode.ValidationFailure, exitCode);
         Assert.Contains("Available commands:", text);
+    }
+
+    private static CliCommandHandler CreateHandler() =>
+        new(new StubPlanBuilder(), new StubPlanSerializer());
+
+    private sealed class StubPlanBuilder : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => throw new NotImplementedException();
+    }
+
+    private sealed class StubPlanSerializer : IPlanSerializer
+    {
+        public void Write(string outputPath, RenamePlan plan) => throw new NotImplementedException();
     }
 }

--- a/src/Renamer.Tests/CLI/CliCommandHandlerTests.cs
+++ b/src/Renamer.Tests/CLI/CliCommandHandlerTests.cs
@@ -1,15 +1,16 @@
 using Renamer.Cli.Commands;
+using Renamer.Core.Contracts;
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
 
 namespace Renamer.Tests.CLI;
 
 public sealed class CliCommandHandlerTests
 {
-    private readonly CliCommandHandler _handler = new();
-
     [Fact]
     public void Handle_Help_ReturnsSuccessAndHelpLines()
     {
-        var result = _handler.Handle(new CliCommand(CliCommandType.Help, "help"));
+        var result = CreateHandler().Handle(new CliCommand(CliCommandType.Help, "help"));
 
         Assert.Equal(ProcessExitCode.Success, result.ExitCode);
         Assert.Contains("Available commands:", result.OutputLines);
@@ -18,10 +19,32 @@ public sealed class CliCommandHandlerTests
     [Fact]
     public void Handle_Invalid_ReturnsValidationFailureAndHelpLines()
     {
-        var result = _handler.Handle(
+        var result = CreateHandler().Handle(
             new CliCommand(CliCommandType.Invalid, "wat", CliCommandParseError.UnsupportedCommand));
 
         Assert.Equal(ProcessExitCode.ValidationFailure, result.ExitCode);
         Assert.Contains("Available commands:", result.OutputLines);
+    }
+
+    [Fact]
+    public void Handle_PlanWithMissingArguments_ReturnsValidationFailure()
+    {
+        var result = CreateHandler().Handle(new CliCommand(CliCommandType.Plan, "plan", Arguments: ["--root", "/tmp/root"]));
+
+        Assert.Equal(ProcessExitCode.ValidationFailure, result.ExitCode);
+        Assert.Contains("Available commands:", result.OutputLines);
+    }
+
+    private static CliCommandHandler CreateHandler() =>
+        new(new StubPlanBuilder(), new StubPlanSerializer());
+
+    private sealed class StubPlanBuilder : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => throw new NotImplementedException();
+    }
+
+    private sealed class StubPlanSerializer : IPlanSerializer
+    {
+        public void Write(string outputPath, RenamePlan plan) => throw new NotImplementedException();
     }
 }

--- a/src/Renamer.Tests/CLI/CliCommandParserTests.cs
+++ b/src/Renamer.Tests/CLI/CliCommandParserTests.cs
@@ -34,4 +34,13 @@ public sealed class CliCommandParserTests
         Assert.Equal(CliCommandParseError.UnsupportedCommand, result.ParseError);
         Assert.Equal("wat", result.CommandText);
     }
+
+    [Fact]
+    public void Parse_PlanCommand_PreservesRemainingArguments()
+    {
+        var result = CliCommandParser.Parse(["plan", "--root", "/photos", "--out", "/tmp/rename-plan.json"]);
+
+        Assert.Equal(CliCommandType.Plan, result.Type);
+        Assert.Equal(["--root", "/photos", "--out", "/tmp/rename-plan.json"], result.Arguments);
+    }
 }

--- a/src/Renamer.Tests/CLI/CliPlanCommandTests.cs
+++ b/src/Renamer.Tests/CLI/CliPlanCommandTests.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Renamer.Cli.Commands;
+using Renamer.Core.Contracts;
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
+
+namespace Renamer.Tests.CLI;
+
+public sealed class CliPlanCommandTests : IDisposable
+{
+    private readonly string tempDirectory = Path.Combine(Path.GetTempPath(), "renamer-cli-plan-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Handle_PlanWithValidArguments_WritesPlanJsonAndReturnsSuccess()
+    {
+        Directory.CreateDirectory(tempDirectory);
+        var rootPath = Path.Combine(tempDirectory, "root");
+        Directory.CreateDirectory(rootPath);
+        var outputPath = Path.Combine(tempDirectory, "out", "rename-plan.json");
+        var handler = new CliCommandHandler(new FakePlanBuilder(CreatePlan(rootPath)), new PlanSerializer());
+
+        var result = handler.Handle(new CliCommand(
+            CliCommandType.Plan,
+            "plan",
+            Arguments: ["--root", rootPath, "--out", outputPath]));
+
+        Assert.Equal(ProcessExitCode.Success, result.ExitCode);
+        Assert.True(File.Exists(outputPath));
+        using var document = JsonDocument.Parse(File.ReadAllText(outputPath));
+        Assert.Equal(rootPath, document.RootElement.GetProperty("rootPath").GetString());
+    }
+
+    [Fact]
+    public void Handle_PlanWhenRootPathIsMissing_ReturnsIoFailure()
+    {
+        var handler = new CliCommandHandler(new FakePlanBuilder(CreatePlan("/unused")), new PlanSerializer());
+
+        var result = handler.Handle(new CliCommand(
+            CliCommandType.Plan,
+            "plan",
+            Arguments: ["--root", Path.Combine(tempDirectory, "missing"), "--out", Path.Combine(tempDirectory, "rename-plan.json")]));
+
+        Assert.Equal(ProcessExitCode.IoFailure, result.ExitCode);
+    }
+
+    [Fact]
+    public void Handle_PlanWhenPlanBuilderThrowsUnexpectedError_ReturnsUnexpectedRuntimeError()
+    {
+        Directory.CreateDirectory(tempDirectory);
+        var rootPath = Path.Combine(tempDirectory, "root");
+        Directory.CreateDirectory(rootPath);
+        var handler = new CliCommandHandler(new ThrowingPlanBuilder(), new PlanSerializer());
+
+        var result = handler.Handle(new CliCommand(
+            CliCommandType.Plan,
+            "plan",
+            Arguments: ["--root", rootPath, "--out", Path.Combine(tempDirectory, "rename-plan.json")]));
+
+        Assert.Equal(ProcessExitCode.UnexpectedRuntimeError, result.ExitCode);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    private static RenamePlan CreatePlan(string rootPath) =>
+        new()
+        {
+            SchemaVersion = "1.0",
+            PlanId = "d609111f-4fbb-4de3-8d6c-faf102a6fdb0",
+            CreatedAtUtc = "2026-03-01T16:10:00Z",
+            RootPath = rootPath,
+            Operations =
+            [
+                new RenamePlanOperation
+                {
+                    OpId = "7c730a84-4b07-4f56-8758-9906cf488e6b",
+                    SourcePath = Path.Combine(rootPath, "Trip A"),
+                    PlannedDestinationPath = Path.Combine(rootPath, "2024-06-12 - 2024-06-14 - Trip A"),
+                    Reason = new RenamePlanReason
+                    {
+                        StartDate = "2024-06-12",
+                        EndDate = "2024-06-14",
+                        FilesConsidered = 12,
+                        FilesSkippedMissingExif = 1
+                    }
+                }
+            ],
+            Summary = new RenamePlanSummary
+            {
+                OperationCount = 1,
+                Warnings = 1
+            }
+        };
+
+    private sealed class FakePlanBuilder(RenamePlan plan) : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => plan;
+    }
+
+    private sealed class ThrowingPlanBuilder : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => throw new InvalidOperationException("boom");
+    }
+}


### PR DESCRIPTION
Closes #12

This slice implements the CLI `plan` command end to end so the command-line tool can generate the canonical `rename-plan.json` artifact from a root folder. Before this change, the CLI accepted `plan` syntactically but did not validate the required arguments, did not invoke the planning pipeline, and did not write any output artifact. For users, that meant the documented `plan` workflow existed in the spec but not in the executable.

The root cause was that the CLI command layer only recognized command names and returned placeholder success paths. It had no command argument payload, no service wiring for plan construction, and no command handler logic for the `plan` flow. The fix adds argument preservation in the parser, wires the core planning services into the CLI application, introduces an `IPlanBuilder` abstraction with the concrete `PlanBuilder`, and implements `plan` handling with contract-ordered validation for `--root` and `--out`, overwrite-capable serialization, and exit-code mapping for validation, IO, and unexpected runtime failures.

The change also adds focused CLI coverage for parser behavior, handler validation, dispatcher dependencies, and end-to-end `plan` command execution. Validation used the slice commands and the standard repo gates:

- `dotnet restore Renamer.sln`
- `dotnet build Renamer.sln`
- `dotnet run --project src/Renamer.Cli -- plan --root ./samples --out /tmp/rename-plan.json`
- `dotnet test Renamer.sln --filter "FullyQualifiedName~CliPlanCommand"`
- `dotnet test Renamer.sln`

The matching project work item is issue `#12`, which is already in `In Progress` on the project board for this slice.
