### PR TITLE
[codex] 220 serilog ui bootstrap

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -26,7 +26,7 @@
 - [x] 190 Report JSON writer (`docs/specs/190-report-json-writer.md`)
 - [x] 200 CLI plan command (`docs/specs/200-cli-plan-command.md`)
 - [x] 210 CLI apply command (`docs/specs/210-cli-apply-command.md`)
-- [ ] 220 Serilog UI bootstrap (`docs/specs/220-serilog-ui-bootstrap.md`)
+- [x] 220 Serilog UI bootstrap (`docs/specs/220-serilog-ui-bootstrap.md`)
 - [ ] 230 Desktop plan view (`docs/specs/230-maui-plan-view.md`)
 - [ ] 240 Desktop apply flow (`docs/specs/240-maui-apply-flow.md`)
 

--- a/src/Renamer.Tests/Renamer.Tests.csproj
+++ b/src/Renamer.Tests/Renamer.Tests.csproj
@@ -23,4 +23,10 @@
     <ProjectReference Include="..\Renamer.Core\Renamer.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Renamer.UI\Runtime\IRuntimeEnvironment.cs" Link="UI\Runtime\IRuntimeEnvironment.cs" />
+    <Compile Include="..\Renamer.UI\Runtime\RuntimePlatform.cs" Link="UI\Runtime\RuntimePlatform.cs" />
+    <Compile Include="..\Renamer.UI\UiLogPathProvider.cs" Link="UI\UiLogPathProvider.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Renamer.Tests/UI/UiLoggingTests.cs
+++ b/src/Renamer.Tests/UI/UiLoggingTests.cs
@@ -1,0 +1,52 @@
+using Renamer.UI;
+using Renamer.UI.Runtime;
+
+namespace Renamer.Tests.UI;
+
+public sealed class UiLoggingTests
+{
+    private readonly string tempDirectory = Path.Combine(Path.GetTempPath(), "renamer-ui-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void UiLogPathProvider_Windows_UsesLocalAppDataPath()
+    {
+        var runtime = new FakeRuntimeEnvironment(
+            RuntimePlatform.Windows,
+            localApplicationDataPath: @"C:\Users\tester\AppData\Local",
+            homeDirectoryPath: "/unused");
+        var provider = new UiLogPathProvider(runtime);
+
+        var actual = provider.GetLogFilePath("renamer-ui");
+
+        var expected = Path.Combine(@"C:\Users\tester\AppData\Local", "Renamer", "logs", "renamer-ui.log");
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void UiLogPathProvider_MacOS_UsesLibraryLogsPath()
+    {
+        var homePath = Path.Combine(tempDirectory, "home");
+        var runtime = new FakeRuntimeEnvironment(
+            RuntimePlatform.MacOS,
+            localApplicationDataPath: null,
+            homeDirectoryPath: homePath);
+        var provider = new UiLogPathProvider(runtime);
+
+        var actual = provider.GetLogFilePath("renamer-ui");
+
+        var expected = Path.Combine(homePath, "Library", "Logs", "Renamer", "renamer-ui.log");
+        Assert.Equal(expected, actual);
+    }
+
+    private sealed class FakeRuntimeEnvironment(
+        RuntimePlatform platform,
+        string? localApplicationDataPath,
+        string? homeDirectoryPath) : IRuntimeEnvironment
+    {
+        public RuntimePlatform Platform { get; } = platform;
+
+        public string? LocalApplicationDataPath { get; } = localApplicationDataPath;
+
+        public string? HomeDirectoryPath { get; } = homeDirectoryPath;
+    }
+}

--- a/src/Renamer.UI/MauiProgram.cs
+++ b/src/Renamer.UI/MauiProgram.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Renamer.Core.Logging;
+using Renamer.UI.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
 
 namespace Renamer.UI;
 
@@ -7,6 +11,11 @@ public static class MauiProgram
 	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder();
+		var runtimeEnvironment = new RuntimeEnvironment();
+		var logPathProvider = new UiLogPathProvider(runtimeEnvironment);
+		var loggingBootstrap = new UiLoggingBootstrap(logPathProvider);
+		var logger = loggingBootstrap.CreateLogger();
+
 		builder
 			.UseMauiApp<App>()
 			.ConfigureFonts(fonts =>
@@ -18,7 +27,16 @@ public static class MauiProgram
 #if DEBUG
 		builder.Logging.AddDebug();
 #endif
+		builder.Services.AddSingleton<IRuntimeEnvironment>(runtimeEnvironment);
+		builder.Services.AddSingleton<ILogPathProvider>(logPathProvider);
+		builder.Services.AddSingleton(loggingBootstrap);
+		builder.Logging.ClearProviders();
+		builder.Logging.AddSerilog(logger, dispose: true);
 
-		return builder.Build();
+		var app = builder.Build();
+		var appLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Renamer.UI.MauiProgram");
+		loggingBootstrap.RegisterUnhandledExceptionLogging(appLogger);
+		appLogger.LogInformation("UI startup complete.");
+		return app;
 	}
 }

--- a/src/Renamer.UI/Renamer.UI.csproj
+++ b/src/Renamer.UI/Renamer.UI.csproj
@@ -64,6 +64,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+		<PackageReference Include="Serilog" Version="4.3.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Renamer.UI/Runtime/IRuntimeEnvironment.cs
+++ b/src/Renamer.UI/Runtime/IRuntimeEnvironment.cs
@@ -1,0 +1,10 @@
+namespace Renamer.UI.Runtime;
+
+public interface IRuntimeEnvironment
+{
+    RuntimePlatform Platform { get; }
+
+    string? LocalApplicationDataPath { get; }
+
+    string? HomeDirectoryPath { get; }
+}

--- a/src/Renamer.UI/Runtime/RuntimeEnvironment.cs
+++ b/src/Renamer.UI/Runtime/RuntimeEnvironment.cs
@@ -1,0 +1,15 @@
+namespace Renamer.UI.Runtime;
+
+public sealed class RuntimeEnvironment : IRuntimeEnvironment
+{
+    public RuntimePlatform Platform =>
+        OperatingSystem.IsWindows() ? RuntimePlatform.Windows :
+        OperatingSystem.IsMacCatalyst() || OperatingSystem.IsMacOS() ? RuntimePlatform.MacOS :
+        RuntimePlatform.Other;
+
+    public string? LocalApplicationDataPath =>
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+    public string? HomeDirectoryPath =>
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+}

--- a/src/Renamer.UI/Runtime/RuntimePlatform.cs
+++ b/src/Renamer.UI/Runtime/RuntimePlatform.cs
@@ -1,0 +1,8 @@
+namespace Renamer.UI.Runtime;
+
+public enum RuntimePlatform
+{
+    Windows,
+    MacOS,
+    Other
+}

--- a/src/Renamer.UI/UiLogPathProvider.cs
+++ b/src/Renamer.UI/UiLogPathProvider.cs
@@ -1,0 +1,63 @@
+using Renamer.Core.Logging;
+using Renamer.UI.Runtime;
+
+namespace Renamer.UI;
+
+public sealed class UiLogPathProvider(IRuntimeEnvironment runtimeEnvironment) : ILogPathProvider
+{
+    public string GetLogFilePath(string executableName)
+    {
+        if (string.IsNullOrWhiteSpace(executableName))
+        {
+            throw new ArgumentException("Executable name is required.", nameof(executableName));
+        }
+
+        var logFileName = $"{executableName}.log";
+        var directory = ResolveLogDirectory(runtimeEnvironment.Platform);
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, logFileName);
+    }
+
+    private string ResolveLogDirectory(RuntimePlatform platform)
+    {
+        return platform switch
+        {
+            RuntimePlatform.Windows => ResolveWindowsLogDirectory(),
+            RuntimePlatform.MacOS => ResolveMacLogDirectory(),
+            _ => ResolveDefaultLogDirectory()
+        };
+    }
+
+    private string ResolveWindowsLogDirectory()
+    {
+        var localAppData = runtimeEnvironment.LocalApplicationDataPath;
+        if (string.IsNullOrWhiteSpace(localAppData))
+        {
+            throw new InvalidOperationException("Local application data path is not available.");
+        }
+
+        return Path.Combine(localAppData, "Renamer", "logs");
+    }
+
+    private string ResolveMacLogDirectory()
+    {
+        var homePath = runtimeEnvironment.HomeDirectoryPath;
+        if (string.IsNullOrWhiteSpace(homePath))
+        {
+            throw new InvalidOperationException("User home directory is not available.");
+        }
+
+        return Path.Combine(homePath, "Library", "Logs", "Renamer");
+    }
+
+    private string ResolveDefaultLogDirectory()
+    {
+        var homePath = runtimeEnvironment.HomeDirectoryPath;
+        if (string.IsNullOrWhiteSpace(homePath))
+        {
+            throw new InvalidOperationException("User home directory is not available.");
+        }
+
+        return Path.Combine(homePath, ".local", "state", "Renamer", "logs");
+    }
+}

--- a/src/Renamer.UI/UiLoggingBootstrap.cs
+++ b/src/Renamer.UI/UiLoggingBootstrap.cs
@@ -1,0 +1,46 @@
+using Renamer.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Serilog;
+
+namespace Renamer.UI;
+
+public sealed class UiLoggingBootstrap
+{
+    private readonly ILogPathProvider logPathProvider;
+
+    public UiLoggingBootstrap(ILogPathProvider logPathProvider)
+    {
+        this.logPathProvider = logPathProvider ?? throw new ArgumentNullException(nameof(logPathProvider));
+    }
+
+    public Serilog.Core.Logger CreateLogger()
+    {
+        var logFilePath = logPathProvider.GetLogFilePath("renamer-ui");
+        return new LoggerConfiguration()
+            .Enrich.WithProperty("Executable", "renamer-ui")
+            .WriteTo.Console()
+            .WriteTo.File(logFilePath, shared: true)
+            .CreateLogger();
+    }
+
+    public void RegisterUnhandledExceptionLogging(Microsoft.Extensions.Logging.ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        AppDomain.CurrentDomain.UnhandledException += (_, args) =>
+        {
+            if (args.ExceptionObject is Exception exception)
+            {
+                logger.LogCritical(exception, "Unhandled app domain exception in UI process.");
+                return;
+            }
+
+            logger.LogCritical("Unhandled app domain exception in UI process.");
+        };
+
+        TaskScheduler.UnobservedTaskException += (_, args) =>
+        {
+            logger.LogCritical(args.Exception, "Unobserved task exception in UI process.");
+        };
+    }
+}


### PR DESCRIPTION
Closes #14

This slice configures desktop UI operational logging from application startup so the MAUI desktop wrapper now follows the same logging contract as the CLI. Before this change, `Renamer.UI` still used the default template startup path, had no Serilog provider configured, did not resolve an OS-aware long-lived log path through `ILogPathProvider`, and did not have a stable place to capture startup or unhandled exception logging. That meant the desktop app lacked the baseline operational diagnostics required by the spec.

The branch adds the Serilog packages already used by the CLI, introduces a UI runtime-environment abstraction and `UiLogPathProvider` that follow the same Windows and macOS log directory contract, and wires a `UiLoggingBootstrap` into `MauiProgram` so logging is configured before the app services are used. It writes to console plus `renamer-ui.log`, logs startup completion, and registers handlers for app-domain and unobserved task exceptions. For automated coverage, the branch adds focused UI logging path tests in the existing test project by linking the pure path-provider source files into the test assembly instead of trying to host the MAUI app directly under the plain `net10.0` test target.

Validation used the slice commands plus manual desktop confirmation:

- `dotnet build src/Renamer.UI/Renamer.UI.csproj`
- `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~UiLogging"`
- `dotnet test Renamer.sln`
- Manual smoke check: launched the UI and confirmed `renamer-ui.log` was created/appended with log output

This slice only establishes the UI logging bootstrap and exception hooks. Later UI slices can add feature-level operational logs on top of this shared startup infrastructure without reworking the initialization path.
