### PR TITLE
[codex] 250 desktop plan generation flow

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -29,7 +29,7 @@
 - [x] 220 Serilog UI bootstrap (`docs/specs/220-serilog-ui-bootstrap.md`)
 - [x] 230 Desktop plan view (`docs/specs/230-maui-plan-view.md`)
 - [x] 240 Desktop apply flow (`docs/specs/240-maui-apply-flow.md`)
-- [ ] 250 Desktop plan generation flow (`docs/specs/250-maui-plan-generation-flow.md`)
+- [x] 250 Desktop plan generation flow (`docs/specs/250-maui-plan-generation-flow.md`)
 
 ## Validation
 - [ ] Windows smoke test

--- a/src/Renamer.Tests/Renamer.Tests.csproj
+++ b/src/Renamer.Tests/Renamer.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="..\Renamer.UI\Runtime\IRuntimeEnvironment.cs" Link="UI\Runtime\IRuntimeEnvironment.cs" />
     <Compile Include="..\Renamer.UI\Runtime\RuntimePlatform.cs" Link="UI\Runtime\RuntimePlatform.cs" />
     <Compile Include="..\Renamer.UI\Plans\IPlanFilePicker.cs" Link="UI\Plans\IPlanFilePicker.cs" />
+    <Compile Include="..\Renamer.UI\Plans\IFolderPathPicker.cs" Link="UI\Plans\IFolderPathPicker.cs" />
     <Compile Include="..\Renamer.UI\Plans\IRootPathOpener.cs" Link="UI\Plans\IRootPathOpener.cs" />
     <Compile Include="..\Renamer.UI\Plans\IPlanViewModel.cs" Link="UI\Plans\IPlanViewModel.cs" />
     <Compile Include="..\Renamer.UI\Plans\ApplyResultItem.cs" Link="UI\Plans\ApplyResultItem.cs" />

--- a/src/Renamer.Tests/UI/ApplyFlowViewModelTests.cs
+++ b/src/Renamer.Tests/UI/ApplyFlowViewModelTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Renamer.Core.Contracts;
 using Renamer.Core.Execution;
+using Renamer.Core.Planning;
 using Renamer.Core.Serialization;
 using Renamer.UI.Plans;
 
@@ -13,8 +14,10 @@ public sealed class ApplyFlowViewModelTests
     {
         var plan = CreatePlan();
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(plan),
             new FakePlanSerializer(plan),
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(CreateCompletedReport()),
             NullLogger<PlanViewModel>.Instance)
@@ -45,8 +48,10 @@ public sealed class ApplyFlowViewModelTests
     {
         var plan = CreatePlan();
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(plan),
             new FakePlanSerializer(plan),
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(CreateRetryAbortReport()),
             NullLogger<PlanViewModel>.Instance)
@@ -70,8 +75,10 @@ public sealed class ApplyFlowViewModelTests
     {
         var serializer = new TwoStagePlanSerializer(CreatePlan(), new InvalidDataException("unsupported schema"));
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
             serializer,
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(CreateCompletedReport()),
             NullLogger<PlanViewModel>.Instance)
@@ -93,8 +100,10 @@ public sealed class ApplyFlowViewModelTests
     {
         var plan = CreatePlan();
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(plan),
             new FakePlanSerializer(plan),
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new ThrowingApplyEngine(new DirectoryNotFoundException("source directory missing")),
             NullLogger<PlanViewModel>.Instance)
@@ -214,6 +223,11 @@ public sealed class ApplyFlowViewModelTests
         public RenameReport Execute(RenamePlan plan) => report;
     }
 
+    private sealed class FakePlanBuilder(RenamePlan plan) : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => plan;
+    }
+
     private sealed class TwoStagePlanSerializer(RenamePlan plan, Exception applyException) : IPlanSerializer
     {
         private int readCount;
@@ -240,6 +254,12 @@ public sealed class ApplyFlowViewModelTests
     private sealed class FakePlanFilePicker(string? selectedPath) : IPlanFilePicker
     {
         public Task<string?> PickPlanPathAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(selectedPath);
+    }
+
+    private sealed class FakeFolderPathPicker(string? selectedPath) : IFolderPathPicker
+    {
+        public Task<string?> PickFolderPathAsync(string title, CancellationToken cancellationToken = default) =>
             Task.FromResult(selectedPath);
     }
 

--- a/src/Renamer.Tests/UI/PlanGenerationViewModelTests.cs
+++ b/src/Renamer.Tests/UI/PlanGenerationViewModelTests.cs
@@ -1,0 +1,195 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Renamer.Core.Contracts;
+using Renamer.Core.Execution;
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
+using Renamer.UI.Plans;
+
+namespace Renamer.Tests.UI;
+
+public sealed class PlanGenerationViewModelTests
+{
+    [Fact]
+    public async Task GeneratePlanAsync_WithValidInputs_WritesPlanAndPopulatesPreviewContext()
+    {
+        var existingDirectory = Path.GetTempPath();
+        var plan = CreatePlan();
+        var serializer = new RecordingPlanSerializer(plan);
+        var viewModel = new PlanViewModel(
+            new FakePlanBuilder(plan),
+            serializer,
+            new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
+            new FakeRootPathOpener(),
+            new FakeApplyEngine(),
+            NullLogger<PlanViewModel>.Instance)
+        {
+            GenerationRootPath = existingDirectory,
+            GenerationOutputDirectoryPath = existingDirectory,
+            PlanFileName = "rename-plan.json"
+        };
+
+        await viewModel.GeneratePlanAsync();
+
+        Assert.False(viewModel.IsGenerating);
+        Assert.False(viewModel.HasGenerationError);
+        Assert.True(viewModel.IsLoaded);
+        Assert.Equal(Path.Combine(existingDirectory, "rename-plan.json"), viewModel.PlanPath);
+        Assert.Equal(Path.Combine(existingDirectory, "rename-plan.json"), serializer.WrittenPath);
+        Assert.Equal(existingDirectory, serializer.WrittenPlan?.RootPath);
+        Assert.Equal("Loaded 1 planned operation(s).", viewModel.StatusMessage);
+        Assert.Equal("Plan generated: rename-plan.json", viewModel.GenerationStatusMessage);
+        Assert.Single(viewModel.Operations);
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_WithMissingRootPath_ShowsValidationError()
+    {
+        var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
+            new RecordingPlanSerializer(CreatePlan()),
+            new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
+            new FakeRootPathOpener(),
+            new FakeApplyEngine(),
+            NullLogger<PlanViewModel>.Instance)
+        {
+            GenerationOutputDirectoryPath = "/tmp/out",
+            PlanFileName = "rename-plan.json"
+        };
+
+        await viewModel.GeneratePlanAsync();
+
+        Assert.True(viewModel.HasGenerationError);
+        Assert.Equal("Plan generation requires a root folder", viewModel.GenerationErrorTitle);
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_WhenSerializerThrowsIOException_ShowsIoError()
+    {
+        var existingDirectory = Path.GetTempPath();
+        var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
+            new ThrowingPlanSerializer(new IOException("read only volume")),
+            new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
+            new FakeRootPathOpener(),
+            new FakeApplyEngine(),
+            NullLogger<PlanViewModel>.Instance)
+        {
+            GenerationRootPath = existingDirectory,
+            GenerationOutputDirectoryPath = existingDirectory,
+            PlanFileName = "rename-plan.json"
+        };
+
+        await viewModel.GeneratePlanAsync();
+
+        Assert.True(viewModel.HasGenerationError);
+        Assert.Equal("Plan generation failed due to file system error", viewModel.GenerationErrorTitle);
+        Assert.Contains("read only volume", viewModel.GenerationErrorMessage);
+    }
+
+    [Fact]
+    public async Task BrowseGenerationRootPathAsync_WhenPickerReturnsPath_UpdatesRootPath()
+    {
+        var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
+            new RecordingPlanSerializer(CreatePlan()),
+            new FakePlanFilePicker(null),
+            new FakeFolderPathPicker("/photos"),
+            new FakeRootPathOpener(),
+            new FakeApplyEngine(),
+            NullLogger<PlanViewModel>.Instance);
+
+        await viewModel.BrowseGenerationRootPathAsync();
+
+        Assert.Equal("/photos", viewModel.GenerationRootPath);
+        Assert.Equal("Selected root folder: photos", viewModel.GenerationStatusMessage);
+    }
+
+    private static RenamePlan CreatePlan() =>
+        new()
+        {
+            SchemaVersion = "1.0",
+            PlanId = "d609111f-4fbb-4de3-8d6c-faf102a6fdb0",
+            CreatedAtUtc = "2026-03-01T16:10:00Z",
+            RootPath = "/photos",
+            Operations =
+            [
+                new RenamePlanOperation
+                {
+                    OpId = "7c730a84-4b07-4f56-8758-9906cf488e6b",
+                    SourcePath = "/photos/Trip A",
+                    PlannedDestinationPath = "/photos/2024-06-12 - 2024-06-14 - Trip A",
+                    Reason = new RenamePlanReason
+                    {
+                        StartDate = "2024-06-12",
+                        EndDate = "2024-06-14",
+                        FilesConsidered = 12,
+                        FilesSkippedMissingExif = 1
+                    }
+                }
+            ],
+            Summary = new RenamePlanSummary
+            {
+                OperationCount = 1,
+                Warnings = 1
+            }
+        };
+
+    private sealed class FakePlanBuilder(RenamePlan plan) : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) =>
+            new()
+            {
+                SchemaVersion = plan.SchemaVersion,
+                PlanId = plan.PlanId,
+                CreatedAtUtc = plan.CreatedAtUtc,
+                RootPath = rootPath,
+                Operations = plan.Operations,
+                Summary = plan.Summary
+            };
+    }
+
+    private sealed class RecordingPlanSerializer(RenamePlan planToRead) : IPlanSerializer
+    {
+        public string? WrittenPath { get; private set; }
+
+        public RenamePlan? WrittenPlan { get; private set; }
+
+        public RenamePlan Read(string inputPath) => planToRead;
+
+        public void Write(string outputPath, RenamePlan plan)
+        {
+            WrittenPath = outputPath;
+            WrittenPlan = plan;
+        }
+    }
+
+    private sealed class ThrowingPlanSerializer(Exception exception) : IPlanSerializer
+    {
+        public RenamePlan Read(string inputPath) => throw new NotImplementedException();
+
+        public void Write(string outputPath, RenamePlan plan) => throw exception;
+    }
+
+    private sealed class FakePlanFilePicker(string? selectedPath) : IPlanFilePicker
+    {
+        public Task<string?> PickPlanPathAsync(CancellationToken cancellationToken = default) => Task.FromResult(selectedPath);
+    }
+
+    private sealed class FakeFolderPathPicker(string? selectedPath) : IFolderPathPicker
+    {
+        public Task<string?> PickFolderPathAsync(string title, CancellationToken cancellationToken = default) => Task.FromResult(selectedPath);
+    }
+
+    private sealed class FakeRootPathOpener : IRootPathOpener
+    {
+        public Task OpenAsync(string directoryPath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeApplyEngine : IApplyEngine
+    {
+        public RenameReport Execute(RenamePlan plan) => throw new NotImplementedException();
+    }
+}

--- a/src/Renamer.Tests/UI/PlanViewModelTests.cs
+++ b/src/Renamer.Tests/UI/PlanViewModelTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Renamer.Core.Contracts;
 using Renamer.Core.Execution;
+using Renamer.Core.Planning;
 using Renamer.Core.Serialization;
 using Renamer.UI.Plans;
 
@@ -13,8 +14,10 @@ public sealed class PlanViewModelTests
     public async Task LoadAsync_WithValidPlan_PopulatesSummaryAndOperations()
     {
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
             new FakePlanSerializer(CreatePlan()),
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(),
             NullLogger<PlanViewModel>.Instance)
@@ -45,8 +48,10 @@ public sealed class PlanViewModelTests
     public async Task LoadAsync_WithMissingPath_SetsActionableErrorState()
     {
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
             new FakePlanSerializer(CreatePlan()),
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(),
             NullLogger<PlanViewModel>.Instance);
@@ -63,8 +68,10 @@ public sealed class PlanViewModelTests
     public async Task LoadAsync_WhenSerializerThrows_ShowsInlineErrorState()
     {
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
             new ThrowingPlanSerializer(new InvalidDataException("broken plan")),
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(),
             NullLogger<PlanViewModel>.Instance)
@@ -84,8 +91,10 @@ public sealed class PlanViewModelTests
     public async Task BrowseAsync_WhenPickerReturnsPath_UpdatesPlanPath()
     {
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
             new FakePlanSerializer(CreatePlan()),
             new FakePlanFilePicker("/tmp/picked-plan.json"),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(),
             NullLogger<PlanViewModel>.Instance);
@@ -100,8 +109,10 @@ public sealed class PlanViewModelTests
     public async Task BrowseAsync_WhenPickerThrows_ShowsErrorState()
     {
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
             new FakePlanSerializer(CreatePlan()),
             new ThrowingPlanFilePicker(new InvalidOperationException("picker unavailable")),
+            new FakeFolderPathPicker(null),
             new FakeRootPathOpener(),
             new FakeApplyEngine(),
             NullLogger<PlanViewModel>.Instance);
@@ -117,8 +128,10 @@ public sealed class PlanViewModelTests
     {
         var rootPathOpener = new FakeRootPathOpener();
         var viewModel = new PlanViewModel(
+            new FakePlanBuilder(CreatePlan()),
             new FakePlanSerializer(CreatePlan()),
             new FakePlanFilePicker(null),
+            new FakeFolderPathPicker(null),
             rootPathOpener,
             new FakeApplyEngine(),
             NullLogger<PlanViewModel>.Instance)
@@ -189,6 +202,12 @@ public sealed class PlanViewModelTests
             throw exception;
     }
 
+    private sealed class FakeFolderPathPicker(string? selectedPath) : IFolderPathPicker
+    {
+        public Task<string?> PickFolderPathAsync(string title, CancellationToken cancellationToken = default) =>
+            Task.FromResult(selectedPath);
+    }
+
     private sealed class FakeRootPathOpener : IRootPathOpener
     {
         public string? OpenedPath { get; private set; }
@@ -203,5 +222,10 @@ public sealed class PlanViewModelTests
     private sealed class FakeApplyEngine : IApplyEngine
     {
         public RenameReport Execute(RenamePlan plan) => throw new NotImplementedException();
+    }
+
+    private sealed class FakePlanBuilder(RenamePlan plan) : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => plan;
     }
 }

--- a/src/Renamer.UI/MainPage.xaml
+++ b/src/Renamer.UI/MainPage.xaml
@@ -7,20 +7,93 @@
           Padding="24"
           RowSpacing="18">
         <VerticalStackLayout Spacing="6">
-            <Label Text="Plan Preview"
+            <Label Text="Plan Generation, Preview, and Apply"
                    FontSize="32"
                    FontAttributes="Bold"
                    SemanticProperties.HeadingLevel="Level1" />
-            <Label Text="Load a rename-plan.json artifact to review operations, then run apply and inspect the report."
+            <Label Text="Generate a rename plan from a root folder, review the planned operations, then apply and inspect the report."
                    FontSize="14"
                    TextColor="{AppThemeBinding Light=#5C5C5C, Dark=#B8B8B8}" />
         </VerticalStackLayout>
 
         <Grid Grid.Row="1"
-              ColumnDefinitions="380,*"
+              ColumnDefinitions="400,*"
               ColumnSpacing="18">
             <ScrollView>
                 <VerticalStackLayout Spacing="16">
+                    <Border StrokeThickness="1"
+                            Padding="16">
+                        <VerticalStackLayout Spacing="12">
+                            <Label Text="Generate Plan"
+                                   FontSize="18"
+                                   FontAttributes="Bold" />
+                            <Label Text="Select the source root folder and destination folder for the generated plan artifact."
+                                   FontSize="13" />
+
+                            <VerticalStackLayout Spacing="6">
+                                <Label Text="Root Folder"
+                                       FontAttributes="Bold" />
+                                <Entry Text="{Binding GenerationRootPath}"
+                                       Placeholder="/path/to/photo-root"
+                                       ClearButtonVisibility="WhileEditing" />
+                                <Button Text="Browse Root Folder"
+                                        Clicked="OnBrowseGenerationRootClicked" />
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="6">
+                                <Label Text="Output Folder"
+                                       FontAttributes="Bold" />
+                                <Entry Text="{Binding GenerationOutputDirectoryPath}"
+                                       Placeholder="/path/to/output-folder"
+                                       ClearButtonVisibility="WhileEditing" />
+                                <Button Text="Browse Output Folder"
+                                        Clicked="OnBrowseGenerationOutputDirectoryClicked" />
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="6">
+                                <Label Text="Plan File Name"
+                                       FontAttributes="Bold" />
+                                <Entry Text="{Binding PlanFileName}"
+                                       Placeholder="rename-plan.json"
+                                       ClearButtonVisibility="WhileEditing" />
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="Generated Plan Path"
+                                       FontAttributes="Bold" />
+                                <Label Text="{Binding GeneratedPlanPathPreview}"
+                                       FontSize="12"
+                                       LineBreakMode="WordWrap"
+                                       TextColor="{AppThemeBinding Light=#0F4C81, Dark=#8CC8FF}" />
+                            </VerticalStackLayout>
+
+                            <HorizontalStackLayout Spacing="10">
+                                <Button Text="Generate and Load"
+                                        Clicked="OnGeneratePlanClicked"
+                                        IsEnabled="{Binding CanGenerate}" />
+                                <ActivityIndicator IsRunning="{Binding IsGenerating}"
+                                                   IsVisible="{Binding IsGenerating}"
+                                                   VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+
+                            <Label Text="{Binding GenerationStatusMessage}"
+                                   FontSize="13" />
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <Border StrokeThickness="1"
+                            Padding="16"
+                            IsVisible="{Binding HasGenerationError}">
+                        <VerticalStackLayout Spacing="8">
+                            <Label Text="{Binding GenerationErrorTitle}"
+                                   FontSize="16"
+                                   FontAttributes="Bold"
+                                   TextColor="#9A3412" />
+                            <Label Text="{Binding GenerationErrorMessage}"
+                                   FontSize="13" />
+                        </VerticalStackLayout>
+                    </Border>
+
                     <Border StrokeThickness="1"
                             Padding="16">
                         <VerticalStackLayout Spacing="12">

--- a/src/Renamer.UI/MainPage.xaml.cs
+++ b/src/Renamer.UI/MainPage.xaml.cs
@@ -39,4 +39,22 @@ public partial class MainPage : ContentPage
         logger.LogInformation("Apply button clicked.");
         await viewModel.ApplyAsync();
     }
+
+    private async void OnBrowseGenerationRootClicked(object? sender, EventArgs e)
+    {
+        logger.LogInformation("Generation root browse button clicked.");
+        await viewModel.BrowseGenerationRootPathAsync();
+    }
+
+    private async void OnBrowseGenerationOutputDirectoryClicked(object? sender, EventArgs e)
+    {
+        logger.LogInformation("Generation output directory browse button clicked.");
+        await viewModel.BrowseGenerationOutputDirectoryAsync();
+    }
+
+    private async void OnGeneratePlanClicked(object? sender, EventArgs e)
+    {
+        logger.LogInformation("Generate plan button clicked.");
+        await viewModel.GeneratePlanAsync();
+    }
 }

--- a/src/Renamer.UI/MauiProgram.cs
+++ b/src/Renamer.UI/MauiProgram.cs
@@ -1,6 +1,12 @@
-﻿using Renamer.Core.Execution;
+﻿using CommunityToolkit.Maui;
+using CommunityToolkit.Maui.Storage;
+using Renamer.Core.Execution;
+using Renamer.Core.Exif;
+using Renamer.Core.IO;
 using Renamer.Core.Logging;
+using Renamer.Core.Planning;
 using Renamer.Core.Serialization;
+using Renamer.Core.Time;
 using Renamer.UI.Plans;
 using Renamer.UI.Runtime;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +28,7 @@ public static class MauiProgram
 
 		builder
 			.UseMauiApp<App>()
+			.UseMauiCommunityToolkit()
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -36,8 +43,18 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IRuntimeEnvironment>(runtimeEnvironment);
 		builder.Services.AddSingleton<ILogPathProvider>(logPathProvider);
 		builder.Services.AddSingleton(loggingBootstrap);
+		builder.Services.AddSingleton<IClock, SystemClock>();
+		builder.Services.AddSingleton<IExifMetadataReader, MetadataExtractorExifMetadataReader>();
+		builder.Services.AddSingleton<IExifService, ExifService>();
+		builder.Services.AddSingleton<IFolderDateRangeCalculator, FolderDateRangeCalculator>();
+		builder.Services.AddSingleton<IFolderNameGenerator, FolderNameGenerator>();
+		builder.Services.AddSingleton<IConflictRetryPolicy, ConflictRetryPolicy>();
+		builder.Services.AddSingleton<IPlanBuilder, PlanBuilder>();
 		builder.Services.AddSingleton<IPlanSerializer, PlanSerializer>();
+		builder.Services.AddSingleton<IDirectoryMover, DirectoryMover>();
 		builder.Services.AddSingleton<IApplyEngine, ApplyEngine>();
+		builder.Services.AddSingleton<IFolderPicker>(FolderPicker.Default);
+		builder.Services.AddSingleton<IFolderPathPicker, FolderPathPicker>();
 		builder.Services.AddSingleton<IPlanFilePicker, PlanFilePicker>();
 		builder.Services.AddSingleton<IRootPathOpener, RootPathOpener>();
 		builder.Services.AddSingleton<IPlanViewModel, PlanViewModel>();

--- a/src/Renamer.UI/Plans/FolderPathPicker.cs
+++ b/src/Renamer.UI/Plans/FolderPathPicker.cs
@@ -1,0 +1,42 @@
+using CommunityToolkit.Maui.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Renamer.UI.Plans;
+
+public sealed class FolderPathPicker(IFolderPicker folderPicker, ILogger<FolderPathPicker> logger) : IFolderPathPicker
+{
+    public async Task<string?> PickFolderPathAsync(string title, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+
+        logger.LogInformation("Opening native folder picker with title {Title}.", title);
+
+        try
+        {
+            var result = await folderPicker.PickAsync(title, cancellationToken);
+            if (!result.IsSuccessful)
+            {
+                if (result.Exception is OperationCanceledException)
+                {
+                    logger.LogInformation("Native folder picker canceled.");
+                    return null;
+                }
+
+                throw result.Exception ?? new InvalidOperationException("Native folder picker did not return a successful result.");
+            }
+
+            logger.LogInformation("Native folder picker selected {FolderPath}.", result.Folder.Path);
+            return result.Folder.Path;
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("Native folder picker canceled.");
+            return null;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or IOException or UnauthorizedAccessException)
+        {
+            logger.LogError(ex, "Native folder picker failed.");
+            throw;
+        }
+    }
+}

--- a/src/Renamer.UI/Plans/IFolderPathPicker.cs
+++ b/src/Renamer.UI/Plans/IFolderPathPicker.cs
@@ -1,0 +1,6 @@
+namespace Renamer.UI.Plans;
+
+public interface IFolderPathPicker
+{
+    Task<string?> PickFolderPathAsync(string title, CancellationToken cancellationToken = default);
+}

--- a/src/Renamer.UI/Plans/IPlanViewModel.cs
+++ b/src/Renamer.UI/Plans/IPlanViewModel.cs
@@ -4,6 +4,26 @@ namespace Renamer.UI.Plans;
 
 public interface IPlanViewModel : INotifyPropertyChanged
 {
+    string GenerationRootPath { get; set; }
+
+    string GenerationOutputDirectoryPath { get; set; }
+
+    string PlanFileName { get; set; }
+
+    string GeneratedPlanPathPreview { get; }
+
+    string GenerationStatusMessage { get; }
+
+    string? GenerationErrorTitle { get; }
+
+    string? GenerationErrorMessage { get; }
+
+    bool HasGenerationError { get; }
+
+    bool IsGenerating { get; }
+
+    bool CanGenerate { get; }
+
     string PlanPath { get; set; }
 
     string StatusMessage { get; }
@@ -59,6 +79,12 @@ public interface IPlanViewModel : INotifyPropertyChanged
     System.Collections.ObjectModel.ObservableCollection<PlanOperationItem> Operations { get; }
 
     System.Collections.ObjectModel.ObservableCollection<ApplyResultItem> ApplyResults { get; }
+
+    Task BrowseGenerationRootPathAsync(CancellationToken cancellationToken = default);
+
+    Task BrowseGenerationOutputDirectoryAsync(CancellationToken cancellationToken = default);
+
+    Task GeneratePlanAsync(CancellationToken cancellationToken = default);
 
     Task BrowseAsync(CancellationToken cancellationToken = default);
 

--- a/src/Renamer.UI/Plans/PlanViewModel.cs
+++ b/src/Renamer.UI/Plans/PlanViewModel.cs
@@ -5,19 +5,29 @@ using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Renamer.Core.Contracts;
 using Renamer.Core.Execution;
+using Renamer.Core.Planning;
 using Renamer.Core.Serialization;
 
 namespace Renamer.UI.Plans;
 
 public sealed class PlanViewModel : IPlanViewModel
 {
-    private readonly IPlanFilePicker planFilePicker;
+    private readonly IPlanBuilder planBuilder;
     private readonly IPlanSerializer planSerializer;
+    private readonly IPlanFilePicker planFilePicker;
+    private readonly IFolderPathPicker folderPathPicker;
     private readonly IRootPathOpener rootPathOpener;
     private readonly IApplyEngine applyEngine;
     private readonly ILogger<PlanViewModel> logger;
 
     private RenamePlan? loadedPlan;
+    private string generationRootPath = string.Empty;
+    private string generationOutputDirectoryPath = string.Empty;
+    private string planFileName = "rename-plan.json";
+    private string generationStatusMessage = "Select a root folder and output location to generate a plan.";
+    private string? generationErrorTitle;
+    private string? generationErrorMessage;
+    private bool isGenerating;
     private string planPath = string.Empty;
     private string statusMessage = "Select a rename-plan.json file to preview planned operations.";
     private string? errorMessage;
@@ -40,20 +50,108 @@ public sealed class PlanViewModel : IPlanViewModel
     private bool hasApplyReport;
 
     public PlanViewModel(
+        IPlanBuilder planBuilder,
         IPlanSerializer planSerializer,
         IPlanFilePicker planFilePicker,
+        IFolderPathPicker folderPathPicker,
         IRootPathOpener rootPathOpener,
         IApplyEngine applyEngine,
         ILogger<PlanViewModel> logger)
     {
+        this.planBuilder = planBuilder ?? throw new ArgumentNullException(nameof(planBuilder));
         this.planSerializer = planSerializer ?? throw new ArgumentNullException(nameof(planSerializer));
         this.planFilePicker = planFilePicker ?? throw new ArgumentNullException(nameof(planFilePicker));
+        this.folderPathPicker = folderPathPicker ?? throw new ArgumentNullException(nameof(folderPathPicker));
         this.rootPathOpener = rootPathOpener ?? throw new ArgumentNullException(nameof(rootPathOpener));
         this.applyEngine = applyEngine ?? throw new ArgumentNullException(nameof(applyEngine));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string GenerationRootPath
+    {
+        get => generationRootPath;
+        set
+        {
+            if (SetProperty(ref generationRootPath, value))
+            {
+                OnPropertyChanged(nameof(CanGenerate));
+            }
+        }
+    }
+
+    public string GenerationOutputDirectoryPath
+    {
+        get => generationOutputDirectoryPath;
+        set
+        {
+            if (SetProperty(ref generationOutputDirectoryPath, value))
+            {
+                OnPropertyChanged(nameof(GeneratedPlanPathPreview));
+                OnPropertyChanged(nameof(CanGenerate));
+            }
+        }
+    }
+
+    public string PlanFileName
+    {
+        get => planFileName;
+        set
+        {
+            if (SetProperty(ref planFileName, value))
+            {
+                OnPropertyChanged(nameof(GeneratedPlanPathPreview));
+                OnPropertyChanged(nameof(CanGenerate));
+            }
+        }
+    }
+
+    public string GeneratedPlanPathPreview => BuildGeneratedPlanPathPreview();
+
+    public string GenerationStatusMessage
+    {
+        get => generationStatusMessage;
+        private set => SetProperty(ref generationStatusMessage, value);
+    }
+
+    public string? GenerationErrorTitle
+    {
+        get => generationErrorTitle;
+        private set => SetProperty(ref generationErrorTitle, value);
+    }
+
+    public string? GenerationErrorMessage
+    {
+        get => generationErrorMessage;
+        private set
+        {
+            if (SetProperty(ref generationErrorMessage, value))
+            {
+                OnPropertyChanged(nameof(HasGenerationError));
+            }
+        }
+    }
+
+    public bool HasGenerationError => !string.IsNullOrWhiteSpace(GenerationErrorMessage);
+
+    public bool IsGenerating
+    {
+        get => isGenerating;
+        private set
+        {
+            if (SetProperty(ref isGenerating, value))
+            {
+                OnPropertyChanged(nameof(CanGenerate));
+            }
+        }
+    }
+
+    public bool CanGenerate =>
+        !IsGenerating &&
+        !string.IsNullOrWhiteSpace(GenerationRootPath) &&
+        !string.IsNullOrWhiteSpace(GenerationOutputDirectoryPath) &&
+        !string.IsNullOrWhiteSpace(PlanFileName);
 
     public string PlanPath
     {
@@ -213,6 +311,107 @@ public sealed class PlanViewModel : IPlanViewModel
     }
 
     public ObservableCollection<ApplyResultItem> ApplyResults { get; } = [];
+
+    public async Task BrowseGenerationRootPathAsync(CancellationToken cancellationToken = default)
+    {
+        var selectedPath = await folderPathPicker.PickFolderPathAsync("Select photo root folder", cancellationToken);
+        if (string.IsNullOrWhiteSpace(selectedPath))
+        {
+            GenerationStatusMessage = "Root folder selection canceled.";
+            return;
+        }
+
+        GenerationRootPath = selectedPath;
+        ClearGenerationError();
+        GenerationStatusMessage = $"Selected root folder: {Path.GetFileName(selectedPath)}";
+    }
+
+    public async Task BrowseGenerationOutputDirectoryAsync(CancellationToken cancellationToken = default)
+    {
+        var selectedPath = await folderPathPicker.PickFolderPathAsync("Select output folder for rename-plan.json", cancellationToken);
+        if (string.IsNullOrWhiteSpace(selectedPath))
+        {
+            GenerationStatusMessage = "Output folder selection canceled.";
+            return;
+        }
+
+        GenerationOutputDirectoryPath = selectedPath;
+        ClearGenerationError();
+        GenerationStatusMessage = $"Selected output folder: {Path.GetFileName(selectedPath)}";
+    }
+
+    public async Task GeneratePlanAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(GenerationRootPath))
+        {
+            SetGenerationError("Plan generation requires a root folder", "Select a source root folder before generating a plan.");
+            return;
+        }
+
+        if (!Directory.Exists(GenerationRootPath))
+        {
+            SetGenerationError("Plan generation requires a valid root folder", $"Root folder '{GenerationRootPath}' does not exist.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(GenerationOutputDirectoryPath))
+        {
+            SetGenerationError("Plan generation requires an output folder", "Select an output folder for rename-plan.json.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(PlanFileName))
+        {
+            SetGenerationError("Plan generation requires a file name", "Enter a file name for the generated plan artifact.");
+            return;
+        }
+
+        string outputPath;
+        try
+        {
+            outputPath = Path.Combine(GenerationOutputDirectoryPath, NormalizePlanFileName(PlanFileName));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+        {
+            SetGenerationError("Plan file name is invalid", ex.Message);
+            return;
+        }
+
+        logger.LogInformation("Generating plan from root {RootPath} to {OutputPath}.", GenerationRootPath, outputPath);
+        IsGenerating = true;
+        ClearGenerationError();
+        GenerationStatusMessage = "Generating rename plan...";
+
+        try
+        {
+            var plan = await Task.Run(() => planBuilder.Build(GenerationRootPath), cancellationToken);
+            await Task.Run(() => planSerializer.Write(outputPath, plan), cancellationToken);
+
+            loadedPlan = plan;
+            SetGeneratedPlanPath(outputPath);
+            ErrorMessage = null;
+            Operations.Clear();
+            ClearLoadedData();
+            ResetApplyState();
+            PopulateLoadedState(plan);
+            GenerationStatusMessage = $"Plan generated: {Path.GetFileName(outputPath)}";
+            logger.LogInformation("Generated plan with {OperationCount} operations at {OutputPath}.", plan.Operations.Count, outputPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogError(ex, "Plan generation failed due to file system access.");
+            SetGenerationError("Plan generation failed due to file system error", ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Plan generation failed unexpectedly.");
+            SetGenerationError("Plan generation failed unexpectedly", ex.Message);
+        }
+        finally
+        {
+            IsGenerating = false;
+        }
+    }
 
     public async Task BrowseAsync(CancellationToken cancellationToken = default)
     {
@@ -470,6 +669,19 @@ public sealed class PlanViewModel : IPlanViewModel
         ApplyStatusMessage = "Apply unavailable.";
     }
 
+    private void SetGenerationError(string title, string message)
+    {
+        GenerationErrorTitle = title;
+        GenerationErrorMessage = message;
+        GenerationStatusMessage = "Plan generation unavailable.";
+    }
+
+    private void ClearGenerationError()
+    {
+        GenerationErrorTitle = null;
+        GenerationErrorMessage = null;
+    }
+
     private void LogSkippedResults(RenameReport report)
     {
         foreach (var result in report.Results.Where(result => string.Equals(result.Status, "skipped", StringComparison.Ordinal)))
@@ -480,6 +692,18 @@ public sealed class PlanViewModel : IPlanViewModel
                 result.SourcePath,
                 result.ActualDestinationPath ?? result.PlannedDestinationPath);
         }
+    }
+
+    private void SetGeneratedPlanPath(string outputPath)
+    {
+        if (string.Equals(planPath, outputPath, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        planPath = outputPath;
+        OnPropertyChanged(nameof(PlanPath));
+        OnPropertyChanged(nameof(HasPlanPath));
     }
 
     private void SetState(PlanViewState nextState)
@@ -528,4 +752,32 @@ public sealed class PlanViewModel : IPlanViewModel
 
     private static string FormatDateRange(string startDate, string endDate) =>
         startDate == endDate ? startDate : $"{startDate} to {endDate}";
+
+    private static string NormalizePlanFileName(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException($"Plan file name '{value}' contains invalid characters.");
+        }
+
+        return Path.HasExtension(trimmed) ? trimmed : $"{trimmed}.json";
+    }
+
+    private string BuildGeneratedPlanPathPreview()
+    {
+        if (string.IsNullOrWhiteSpace(GenerationOutputDirectoryPath) || string.IsNullOrWhiteSpace(PlanFileName))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return Path.Combine(GenerationOutputDirectoryPath, NormalizePlanFileName(PlanFileName));
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
+    }
 }

--- a/src/Renamer.UI/Renamer.UI.csproj
+++ b/src/Renamer.UI/Renamer.UI.csproj
@@ -70,7 +70,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
 		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />


### PR DESCRIPTION
## Summary
- add MAUI plan generation UI with native folder picking and plan file naming
- generate and immediately load plan artifacts into the existing preview/apply flow
- cover the new generation behavior with view-model tests and mark slice 250 complete

Closes #28