### PR TITLE
Add UI layout planning slices

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -30,6 +30,9 @@
 - [x] 230 Desktop plan view (`docs/specs/230-maui-plan-view.md`)
 - [x] 240 Desktop apply flow (`docs/specs/240-maui-apply-flow.md`)
 - [x] 250 Desktop plan generation flow (`docs/specs/250-maui-plan-generation-flow.md`)
+- [ ] 260 Desktop stepper shell (`docs/specs/260-maui-stepper-shell.md`)
+- [ ] 270 Desktop preview workspace (`docs/specs/270-maui-preview-workspace.md`)
+- [ ] 280 Desktop apply workspace (`docs/specs/280-maui-apply-workspace.md`)
 
 ## Validation
 - [ ] Windows smoke test

--- a/docs/specs/000-index.md
+++ b/docs/specs/000-index.md
@@ -31,3 +31,7 @@ This folder defines the spec-driven development package for Renamer.
 - `220-serilog-ui-bootstrap.md` - draft - UI operational logging startup.
 - `230-maui-plan-view.md` - draft - Desktop UI plan preview rendering.
 - `240-maui-apply-flow.md` - draft - Desktop UI apply and report flow.
+- `250-maui-plan-generation-flow.md` - draft - Desktop UI plan generation flow.
+- `260-maui-stepper-shell.md` - draft - Desktop UI step-navigation shell and active workspace layout.
+- `270-maui-preview-workspace.md` - draft - Desktop UI preview workspace with summary breakout and operations list.
+- `280-maui-apply-workspace.md` - draft - Desktop UI apply workspace with inline results and generated-plan handoff.

--- a/docs/specs/050-workplan.md
+++ b/docs/specs/050-workplan.md
@@ -35,6 +35,9 @@
   - `230-maui-plan-view.md`
   - `240-maui-apply-flow.md`
   - `250-maui-plan-generation-flow.md`
+  - `260-maui-stepper-shell.md`
+  - `270-maui-preview-workspace.md`
+  - `280-maui-apply-workspace.md`
 
 ## Phase 4: Polish
 - Cross-platform validation on Windows/macOS.

--- a/docs/specs/260-maui-stepper-shell.md
+++ b/docs/specs/260-maui-stepper-shell.md
@@ -1,0 +1,91 @@
+# 260 Desktop Stepper Shell
+
+## Goal
+Introduce a step-navigation shell that moves the desktop UI from stacked left-side cards to a left-stepper plus right-workspace layout for generate, preview, and apply.
+
+## In scope
+- Replace the current left-column stack of functional cards with a compact step list:
+  - `Generate Plan`
+  - `Preview Plan`
+  - `Apply Plan`
+- Render only the active step's workspace in the right panel.
+- Allow non-sequential navigation between steps.
+- Add lightweight step status indicators for:
+  - needs info
+  - error
+  - done
+- Preserve existing plan-generation, plan-loading, preview, and apply behaviors while rearranging layout ownership.
+- Keep desktop targets only (Windows + macOS Mac Catalyst).
+
+## Out of scope
+- Visual card restyling for operations or results.
+- Changes to plan or report schema.
+- Mobile/tablet targets.
+- New rename workflow behavior beyond layout and step-state presentation.
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean:
+   - `git status --short` returns no changes.
+2. Verify current branch is `main`:
+   - `git branch --show-current` returns `main`.
+3. Update local `main` from origin:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main` with required prefix:
+   - `git switch -c codex/260-maui-stepper-shell`
+5. Confirm branch naming matches this slice ID:
+   - `git branch --show-current` equals `codex/260-maui-stepper-shell`.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit code until steps 1-6 are complete.
+
+## Implementation steps
+1. Add a step selection model to the desktop UI ViewModel so `Generate Plan`, `Preview Plan`, and `Apply Plan` can be activated independently.
+2. Refactor the desktop page layout so the left column is a step-navigation rail and the right column hosts the active step content.
+3. Map existing workflow state into step status indicators for needs-info, error, and done without introducing sequential locking.
+4. Keep current commands and bindings working while relocating controls into the active workspace structure.
+5. Add or update tests that verify step selection and status mapping behavior.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build src/Renamer.UI/Renamer.UI.csproj`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~Stepper"`
+
+## Git/PR workflow
+0. Setup - change to `main` branch and pull latest from origin to prepare for new work.
+1. Branch from current `main` using prefix `codex/` (for example `codex/260-maui-stepper-shell`).
+2. Keep one slice per branch and one branch per PR.
+3. Commit only files related to this slice.
+4. If a matching GitHub issue exists, ensure it is `In Progress` before opening the PR.
+5. Open PR back into `main` with slice ID in title/body.
+6. Link the corresponding issue in the PR body:
+   - use `Closes #<issue-number>` when the PR completes the slice
+   - use `Refs #<issue-number>` only for partial work
+7. Include the slice ID in PR title and body.
+
+## Acceptance checks
+- The desktop UI shows a left-side step navigation rail instead of stacked action cards.
+- Selecting a step swaps the right-side workspace without requiring sequential completion.
+- Each step shows a visible status affordance for needs-info, error, or done based on current workflow state.
+- Existing generate, preview, and apply behaviors remain reachable after the layout change.
+
+## Tests
+- Add or update `src/Renamer.Tests/UI/*Stepper*.cs` coverage for step selection, default step, and status mapping.
+
+## Test scope
+- Desktop ViewModel and UI state behavior for step navigation shell only.
+
+## Expected outputs
+- Desktop UI shell layout updates for step navigation and active workspace hosting.
+- ViewModel state for selected step and step status.
+- Targeted tests for shell state behavior.
+
+## Exit criteria
+- The desktop UI uses a stepper-style shell while preserving existing workflow behavior.
+
+## Definition of Done
+- Acceptance checks in this slice are satisfied.
+- Tests listed in this slice are implemented and pass locally.
+- Checklist item for this slice is updated.
+- Branch pre-implementation gate completed before first code edit.
+- Branch name follows `codex/` and maps to this slice ID.
+- PR scope is limited to this slice (no unrelated refactors).
+- If a matching GitHub issue exists, it is linked from the PR and moved to `In Progress` when the slice is picked up.

--- a/docs/specs/270-maui-preview-workspace.md
+++ b/docs/specs/270-maui-preview-workspace.md
@@ -1,0 +1,89 @@
+# 270 Desktop Preview Workspace
+
+## Goal
+Give the preview step a dedicated right-panel workspace that presents plan summary first and planned operations underneath, using the fuller desktop width.
+
+## In scope
+- Move plan preview content into the `Preview Plan` workspace.
+- Show plan summary as a breakout section above the operations list.
+- Keep operations browsing as the primary detailed content below the summary.
+- Retain preview states:
+  - idle
+  - loading
+  - loaded
+  - error
+- Keep summary and operations bound to the existing plan artifact load workflow.
+- Keep desktop targets only (Windows + macOS Mac Catalyst).
+
+## Out of scope
+- Apply execution controls or apply results layout.
+- New filtering, sorting, or search behavior for operations.
+- Visual card restyling beyond layout regrouping.
+- Mobile/tablet targets.
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean:
+   - `git status --short` returns no changes.
+2. Verify current branch is `main`:
+   - `git branch --show-current` returns `main`.
+3. Update local `main` from origin:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main` with required prefix:
+   - `git switch -c codex/270-maui-preview-workspace`
+5. Confirm branch naming matches this slice ID:
+   - `git branch --show-current` equals `codex/270-maui-preview-workspace`.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit code until steps 1-6 are complete.
+
+## Implementation steps
+1. Move the plan artifact load controls and preview messaging into the `Preview Plan` workspace.
+2. Reorganize loaded preview content so summary appears as a breakout section above operations.
+3. Ensure idle, loading, loaded, and error states render within the preview workspace without relying on the old stacked page structure.
+4. Reuse existing plan-loading logic and data models rather than introducing new preview contracts.
+5. Add or update tests for preview workspace state rendering and summary-plus-operations visibility.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build src/Renamer.UI/Renamer.UI.csproj`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~PlanView|FullyQualifiedName~Preview"`
+
+## Git/PR workflow
+0. Setup - change to `main` branch and pull latest from origin to prepare for new work.
+1. Branch from current `main` using prefix `codex/` (for example `codex/270-maui-preview-workspace`).
+2. Keep one slice per branch and one branch per PR.
+3. Commit only files related to this slice.
+4. If a matching GitHub issue exists, ensure it is `In Progress` before opening the PR.
+5. Open PR back into `main` with slice ID in title/body.
+6. Link the corresponding issue in the PR body:
+   - use `Closes #<issue-number>` when the PR completes the slice
+   - use `Refs #<issue-number>` only for partial work
+7. Include the slice ID in PR title and body.
+
+## Acceptance checks
+- The `Preview Plan` step shows plan artifact load controls in the right workspace.
+- When a plan is loaded, summary is shown above operations instead of in a separate left-side card.
+- Preview idle, loading, and error states are contained within the preview workspace.
+- Operations remain readable and scrollable in the wider right-side content area.
+
+## Tests
+- Add or update `src/Renamer.Tests/UI/PlanViewModelTests.cs` and any new preview-workspace coverage needed for state visibility.
+
+## Test scope
+- Preview workspace load, summary display, operations display, and error-state behavior.
+
+## Expected outputs
+- Desktop preview workspace layout updates.
+- Adjusted bindings for preview controls, summary, and operations placement.
+- Targeted tests for preview workspace behavior.
+
+## Exit criteria
+- Users can load and review a plan in a dedicated preview workspace with summary first and operations second.
+
+## Definition of Done
+- Acceptance checks in this slice are satisfied.
+- Tests listed in this slice are implemented and pass locally.
+- Checklist item for this slice is updated.
+- Branch pre-implementation gate completed before first code edit.
+- Branch name follows `codex/` and maps to this slice ID.
+- PR scope is limited to this slice (no unrelated refactors).
+- If a matching GitHub issue exists, it is linked from the PR and moved to `In Progress` when the slice is picked up.

--- a/docs/specs/280-maui-apply-workspace.md
+++ b/docs/specs/280-maui-apply-workspace.md
@@ -1,0 +1,86 @@
+# 280 Desktop Apply Workspace
+
+## Goal
+Give the apply step a dedicated right-panel workspace that combines plan selection, apply execution, and inline results while prepopulating the most recently generated plan path.
+
+## In scope
+- Move apply-related controls into the `Apply Plan` workspace.
+- Show plan artifact selection/loading controls at the top of the apply workspace.
+- Prepopulate the apply plan path from the most recently generated plan when available.
+- Keep support for applying a different previously generated or manually selected plan.
+- Render apply status, error messaging, apply summary, and apply results inline below the load/execute controls.
+- Keep desktop targets only (Windows + macOS Mac Catalyst).
+
+## Out of scope
+- Dedicated standalone results step.
+- New execution semantics or retry policy changes.
+- Visual card restyling beyond layout regrouping.
+- Mobile/tablet targets.
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean:
+   - `git status --short` returns no changes.
+2. Verify current branch is `main`:
+   - `git branch --show-current` returns `main`.
+3. Update local `main` from origin:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main` with required prefix:
+   - `git switch -c codex/280-maui-apply-workspace`
+5. Confirm branch naming matches this slice ID:
+   - `git branch --show-current` equals `codex/280-maui-apply-workspace`.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit code until steps 1-6 are complete.
+
+## Implementation steps
+1. Move plan artifact load controls and apply action controls into the `Apply Plan` workspace.
+2. Ensure plan generation success continues to hand off the generated plan path into the apply context by default.
+3. Keep manual plan browsing/loading available so apply does not depend on the current session's generation path.
+4. Reorganize apply summary, error state, and execution results to render inline under the load and apply controls.
+5. Add or update tests for generated-plan handoff, apply validation, success, and failure visibility in the apply workspace.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build src/Renamer.UI/Renamer.UI.csproj`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~ApplyFlow|FullyQualifiedName~PlanGeneration"`
+
+## Git/PR workflow
+0. Setup - change to `main` branch and pull latest from origin to prepare for new work.
+1. Branch from current `main` using prefix `codex/` (for example `codex/280-maui-apply-workspace`).
+2. Keep one slice per branch and one branch per PR.
+3. Commit only files related to this slice.
+4. If a matching GitHub issue exists, ensure it is `In Progress` before opening the PR.
+5. Open PR back into `main` with slice ID in title/body.
+6. Link the corresponding issue in the PR body:
+   - use `Closes #<issue-number>` when the PR completes the slice
+   - use `Refs #<issue-number>` only for partial work
+7. Include the slice ID in PR title and body.
+
+## Acceptance checks
+- The `Apply Plan` step shows plan selection/load controls and apply controls in the same right-side workspace.
+- When a plan was just generated in the current session, the apply workspace defaults to that generated plan path.
+- Users can still browse or paste a different plan artifact before loading and applying.
+- Apply summary and apply results appear inline underneath the load and execute controls.
+- Apply errors remain clear and actionable in the apply workspace.
+
+## Tests
+- Add or update `src/Renamer.Tests/UI/ApplyFlowViewModelTests.cs` and `src/Renamer.Tests/UI/PlanGenerationViewModelTests.cs` for apply workspace handoff and inline-state behavior.
+
+## Test scope
+- Apply workspace validation, generated-plan handoff, success state, and failure state behavior.
+
+## Expected outputs
+- Desktop apply workspace layout updates.
+- ViewModel support for generated-plan handoff into apply context.
+- Targeted tests for apply workspace behavior.
+
+## Exit criteria
+- Users can load and execute apply in a dedicated workspace with inline summary and results.
+
+## Definition of Done
+- Acceptance checks in this slice are satisfied.
+- Tests listed in this slice are implemented and pass locally.
+- Checklist item for this slice is updated.
+- Branch pre-implementation gate completed before first code edit.
+- Branch name follows `codex/` and maps to this slice ID.
+- PR scope is limited to this slice (no unrelated refactors).
+- If a matching GitHub issue exists, it is linked from the PR and moved to `In Progress` when the slice is picked up.

--- a/src/Renamer.UI/App.xaml.cs
+++ b/src/Renamer.UI/App.xaml.cs
@@ -2,16 +2,16 @@
 
 public partial class App : Application
 {
-	private readonly MainPage mainPage;
+    private readonly MainPage mainPage;
 
-	public App(MainPage mainPage)
-	{
-		this.mainPage = mainPage;
-		InitializeComponent();
-	}
+    public App(MainPage mainPage)
+    {
+        this.mainPage = mainPage;
+        InitializeComponent();
+    }
 
-	protected override Window CreateWindow(IActivationState? activationState)
-	{
-		return new Window(mainPage);
-	}
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        return new Window(mainPage);
+    }
 }

--- a/src/Renamer.UI/AppShell.xaml.cs
+++ b/src/Renamer.UI/AppShell.xaml.cs
@@ -2,8 +2,8 @@
 
 public partial class AppShell : Shell
 {
-	public AppShell()
-	{
-		InitializeComponent();
-	}
+    public AppShell()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Renamer.UI/MainPage.xaml.cs
+++ b/src/Renamer.UI/MainPage.xaml.cs
@@ -5,24 +5,24 @@ namespace Renamer.UI;
 
 public partial class MainPage : ContentPage
 {
-	private readonly IPlanViewModel viewModel;
+    private readonly IPlanViewModel viewModel;
     private readonly ILogger<MainPage> logger;
 
-	public MainPage(IPlanViewModel viewModel, ILogger<MainPage> logger)
-	{
-		this.viewModel = viewModel;
+    public MainPage(IPlanViewModel viewModel, ILogger<MainPage> logger)
+    {
+        this.viewModel = viewModel;
         this.logger = logger;
-		InitializeComponent();
-		BindingContext = viewModel;
-	}
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
 
-	private async void OnBrowseClicked(object? sender, EventArgs e)
-	{
+    private async void OnBrowseClicked(object? sender, EventArgs e)
+    {
         logger.LogInformation("Browse button clicked.");
-		await viewModel.BrowseAsync();
-	}
+        await viewModel.BrowseAsync();
+    }
 
-	private async void OnLoadClicked(object? sender, EventArgs e)
+    private async void OnLoadClicked(object? sender, EventArgs e)
     {
         logger.LogInformation("Load preview button clicked.");
         await viewModel.LoadAsync();

--- a/src/Renamer.UI/MauiProgram.cs
+++ b/src/Renamer.UI/MauiProgram.cs
@@ -17,55 +17,55 @@ namespace Renamer.UI;
 
 public static class MauiProgram
 {
-	public static MauiApp CreateMauiApp()
-	{
-		var builder = MauiApp.CreateBuilder();
-		var runtimeEnvironment = new RuntimeEnvironment();
-		var logPathProvider = new UiLogPathProvider(runtimeEnvironment);
-		var uiLogFilePath = logPathProvider.GetLogFilePath("renamer-ui");
-		var loggingBootstrap = new UiLoggingBootstrap(logPathProvider);
-		var logger = loggingBootstrap.CreateLogger();
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        var runtimeEnvironment = new RuntimeEnvironment();
+        var logPathProvider = new UiLogPathProvider(runtimeEnvironment);
+        var uiLogFilePath = logPathProvider.GetLogFilePath("renamer-ui");
+        var loggingBootstrap = new UiLoggingBootstrap(logPathProvider);
+        var logger = loggingBootstrap.CreateLogger();
 
-		builder
-			.UseMauiApp<App>()
-			.UseMauiCommunityToolkit()
-			.ConfigureFonts(fonts =>
-			{
-				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-			});
+        builder
+            .UseMauiApp<App>()
+            .UseMauiCommunityToolkit()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
 
-		builder.Logging.ClearProviders();
+        builder.Logging.ClearProviders();
 
 #if DEBUG
-		builder.Logging.AddDebug();
+        builder.Logging.AddDebug();
 #endif
-		builder.Services.AddSingleton<IRuntimeEnvironment>(runtimeEnvironment);
-		builder.Services.AddSingleton<ILogPathProvider>(logPathProvider);
-		builder.Services.AddSingleton(loggingBootstrap);
-		builder.Services.AddSingleton<IClock, SystemClock>();
-		builder.Services.AddSingleton<IExifMetadataReader, MetadataExtractorExifMetadataReader>();
-		builder.Services.AddSingleton<IExifService, ExifService>();
-		builder.Services.AddSingleton<IFolderDateRangeCalculator, FolderDateRangeCalculator>();
-		builder.Services.AddSingleton<IFolderNameGenerator, FolderNameGenerator>();
-		builder.Services.AddSingleton<IConflictRetryPolicy, ConflictRetryPolicy>();
-		builder.Services.AddSingleton<IPlanBuilder, PlanBuilder>();
-		builder.Services.AddSingleton<IPlanSerializer, PlanSerializer>();
-		builder.Services.AddSingleton<IDirectoryMover, DirectoryMover>();
-		builder.Services.AddSingleton<IApplyEngine, ApplyEngine>();
-		builder.Services.AddSingleton<IFolderPicker>(FolderPicker.Default);
-		builder.Services.AddSingleton<IFolderPathPicker, FolderPathPicker>();
-		builder.Services.AddSingleton<IPlanFilePicker, PlanFilePicker>();
-		builder.Services.AddSingleton<IRootPathOpener, RootPathOpener>();
-		builder.Services.AddSingleton<IPlanViewModel, PlanViewModel>();
-		builder.Services.AddSingleton<MainPage>();
-		builder.Logging.AddSerilog(logger, dispose: true);
+        builder.Services.AddSingleton<IRuntimeEnvironment>(runtimeEnvironment);
+        builder.Services.AddSingleton<ILogPathProvider>(logPathProvider);
+        builder.Services.AddSingleton(loggingBootstrap);
+        builder.Services.AddSingleton<IClock, SystemClock>();
+        builder.Services.AddSingleton<IExifMetadataReader, MetadataExtractorExifMetadataReader>();
+        builder.Services.AddSingleton<IExifService, ExifService>();
+        builder.Services.AddSingleton<IFolderDateRangeCalculator, FolderDateRangeCalculator>();
+        builder.Services.AddSingleton<IFolderNameGenerator, FolderNameGenerator>();
+        builder.Services.AddSingleton<IConflictRetryPolicy, ConflictRetryPolicy>();
+        builder.Services.AddSingleton<IPlanBuilder, PlanBuilder>();
+        builder.Services.AddSingleton<IPlanSerializer, PlanSerializer>();
+        builder.Services.AddSingleton<IDirectoryMover, DirectoryMover>();
+        builder.Services.AddSingleton<IApplyEngine, ApplyEngine>();
+        builder.Services.AddSingleton<IFolderPicker>(FolderPicker.Default);
+        builder.Services.AddSingleton<IFolderPathPicker, FolderPathPicker>();
+        builder.Services.AddSingleton<IPlanFilePicker, PlanFilePicker>();
+        builder.Services.AddSingleton<IRootPathOpener, RootPathOpener>();
+        builder.Services.AddSingleton<IPlanViewModel, PlanViewModel>();
+        builder.Services.AddSingleton<MainPage>();
+        builder.Logging.AddSerilog(logger, dispose: true);
 
-		var app = builder.Build();
-		var appLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Renamer.UI.MauiProgram");
-		loggingBootstrap.RegisterUnhandledExceptionLogging(appLogger);
-		appLogger.LogInformation("UI log file path resolved to {LogFilePath}.", uiLogFilePath);
-		appLogger.LogInformation("UI startup complete.");
-		return app;
-	}
+        var app = builder.Build();
+        var appLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Renamer.UI.MauiProgram");
+        loggingBootstrap.RegisterUnhandledExceptionLogging(appLogger);
+        appLogger.LogInformation("UI log file path resolved to {LogFilePath}.", uiLogFilePath);
+        appLogger.LogInformation("UI startup complete.");
+        return app;
+    }
 }

--- a/src/Renamer.UI/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/Renamer.UI/Platforms/MacCatalyst/AppDelegate.cs
@@ -5,5 +5,5 @@ namespace Renamer.UI;
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/src/Renamer.UI/Platforms/MacCatalyst/Program.cs
+++ b/src/Renamer.UI/Platforms/MacCatalyst/Program.cs
@@ -5,11 +5,11 @@ namespace Renamer.UI;
 
 public class Program
 {
-	// This is the main entry point of the application.
-	static void Main(string[] args)
-	{
-		// if you want to use a different Application Delegate class from "AppDelegate"
-		// you can specify it here.
-		UIApplication.Main(args, null, typeof(AppDelegate));
-	}
+    // This is the main entry point of the application.
+    static void Main(string[] args)
+    {
+        // if you want to use a different Application Delegate class from "AppDelegate"
+        // you can specify it here.
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
 }


### PR DESCRIPTION
## Summary
- add three new UI planning slice specs for stepper shell, preview workspace, and apply workspace
- update the specs index, workplan, and v1 checklist to include the new UI planning work
- include existing dotnet format whitespace-only cleanup in Renamer.UI files

## Notes
- this PR is for planning/docs and formatting only
- card-style visual refinements for operations and results are intentionally deferred to a later pass