### PR TITLE
docs(specs): 335 ui cleanup design baseline

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -39,6 +39,15 @@
 - [x] 320 Plan review copy refresh (`docs/specs/320-plan-review-copy-refresh.md`)
 - [x] 330 Apply copy refresh (`docs/specs/330-apply-copy-refresh.md`)
 
+## UI cleanup v2 (one PR per item)
+- [ ] 335 UI cleanup design baseline (`docs/specs/335-ui-cleanup-design-baseline.md`)
+- [ ] 340 Thin rail redesign (`docs/specs/340-thin-rail-redesign.md`)
+- [ ] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
+- [ ] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
+- [ ] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)
+- [ ] 380 Stat strip and result banner (`docs/specs/380-stat-strip-and-result-banner.md`)
+- [ ] 390 Compact theme toggle (`docs/specs/390-compact-theme-toggle.md`)
+
 ## Validation
 - [ ] Windows smoke test
 - [ ] macOS smoke test

--- a/docs/specs/000-index.md
+++ b/docs/specs/000-index.md
@@ -40,3 +40,10 @@ This folder defines the spec-driven development package for Renamer.
 - `310-generate-copy-refresh.md` - draft - Generate-step copy refresh for simpler, calmer guidance.
 - `320-plan-review-copy-refresh.md` - draft - Plan review/preview copy refresh for clearer read-only review guidance.
 - `330-apply-copy-refresh.md` - draft - Apply-step copy refresh for direct, low-jargon execution messaging.
+- `335-ui-cleanup-design-baseline.md` - draft - UI cleanup v2 design baseline: thin rail, inline browse buttons, smart defaults, card plan items, stat strip, compact theme toggle.
+- `340-thin-rail-redesign.md` - draft - Thin numbered rail replacing full-card stepper with circular indicator + stacked-letter label.
+- `350-inline-browse-buttons.md` - draft - Inline icon-sized browse buttons; accent primary reserved for commit actions.
+- `360-plan-file-smart-defaults.md` - draft - Smart defaults for output folder and plan filename behind an Advanced disclosure.
+- `370-plan-items-as-cards.md` - draft - Plan preview list restructured as bounded from→to cards with status pills.
+- `380-stat-strip-and-result-banner.md` - draft - Compact stat strip on preview and condensed result banner on apply.
+- `390-compact-theme-toggle.md` - draft - Single icon-pill theme toggle cycling Light/Dark/System, replacing three RadioButtons.

--- a/docs/specs/335-ui-cleanup-design-baseline.md
+++ b/docs/specs/335-ui-cleanup-design-baseline.md
@@ -1,0 +1,142 @@
+# 335 UI Cleanup Design Baseline
+
+## Slice ID
+`335-ui-cleanup-design-baseline`
+
+## Goal
+Capture the visual and structural decisions for the v2 UI cleanup so subsequent implementation slices (340–390) share a single source of truth, and so per-slice specs can stay focused on a single concrete change.
+
+## In scope
+- New `docs/specs/335-ui-cleanup-design-baseline.md` describing:
+  - Design problems being solved (clutter, instructional copy, full-width primary buttons, floaty plan items, oversized title, defaults users should not have to specify).
+  - Selected direction: **thin numbered rail** with vertical stacked-letter step labels, replacing the current full-card rail.
+  - Visual primitives the implementation slices must converge on: small-circle step indicator, stacked-letter labels, cards-not-rows for plan items, inline icon-sized browse buttons, muted "advanced" defaults block, compact icon theme toggle.
+  - Defaults policy: save folder defaults to the photo folder, plan filename defaults to `rename-plan.json`; both surfaces hidden behind an `Advanced ▾` disclosure unless overridden.
+  - Copy voice: friendly but minimal, single-purpose per element.
+  - Map of the implementation slices that follow this one (340–390) and what each owns.
+- Pointer to the wireframe HTML file used to derive the baseline.
+- Cross-references back to `260-maui-stepper-shell.md`, `300-ui-copy-baseline.md`, `310/320/330` copy refresh slices.
+
+## Out of scope
+- Any source code changes (`src/**`).
+- Any `AppStrings.resx` changes.
+- Any test changes.
+- Pixel-precise tokens (colors, exact font sizes) — those are decided in the hi-fi mock that lands alongside slice 340 and become enforceable in 340+ specs.
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean:
+   - `git status --short` returns no changes.
+2. Verify current branch is `main`:
+   - `git branch --show-current` returns `main`.
+3. Update local `main` from origin:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main` with required prefix:
+   - `git switch -c docs/335-ui-cleanup-design-baseline`
+5. Confirm branch naming matches this slice ID:
+   - `git branch --show-current` equals `docs/335-ui-cleanup-design-baseline`.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit other files until steps 1–6 are complete.
+
+## Implementation steps
+1. Add `docs/specs/335-ui-cleanup-design-baseline.md` with the structure described in "In scope".
+2. Add an entry for this slice and the planned 340–390 slices to `docs/checklists/v1.md` under a new "UI cleanup v2 (one PR per item)" section.
+3. Cross-link from `docs/specs/000-index.md` (under whichever section currently lists UI specs) to `335` so it appears in the spec index.
+4. Do not modify any file outside `docs/`.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build Renamer.sln`
+3. `dotnet test Renamer.sln`
+
+(Tests are unaffected; build/test exists to satisfy the standard command sequence and confirm the docs-only change has not broken the working tree.)
+
+## Git/PR workflow
+1. Branch from current `main` using the conventional commit type prefix `docs/`.
+2. Keep the PR scoped to documentation changes only — no `src/**` edits.
+3. Title the PR with a Conventional Commit, for example `docs(specs): 335 ui cleanup design baseline`.
+4. Link the matching issue with `Closes #<issue-number>` when the slice is complete.
+
+## Acceptance checks
+- `docs/specs/335-ui-cleanup-design-baseline.md` exists and lists the 340–390 implementation slices with one-line summaries.
+- `docs/checklists/v1.md` has a new "UI cleanup v2" section with this slice and the 340–390 slices listed and unchecked (except 335 itself, ticked at PR merge time).
+- `docs/specs/000-index.md` references `335`.
+- No files outside `docs/` are modified.
+
+## Tests
+- None — this is a documentation-only slice.
+
+## Test scope
+- Standard `restore` / `build` / `test` must still pass on `main` after the docs are added.
+
+## Expected outputs
+- `docs/specs/335-ui-cleanup-design-baseline.md` (new)
+- `docs/checklists/v1.md` (updated — new section + entry)
+- `docs/specs/000-index.md` (updated — index entry)
+
+## Exit criteria
+- Implementation slices 340–390 can be drafted and reviewed against `335` without re-litigating overall direction.
+
+## Definition of Done
+- Acceptance checks in this slice are satisfied.
+- Standard command sequence passes locally.
+- Checklist entry for `335` is updated to checked at merge.
+- Branch pre-implementation gate completed before first edit.
+- PR scope is limited to `docs/` changes only.
+
+---
+
+# Design baseline content (the document body itself)
+
+> The section below is the **content** that lives inside `335-ui-cleanup-design-baseline.md` once this slice is executed. It is included here so the slice's "expected output" is concrete and reviewable.
+
+## Why we are redesigning
+
+The current desktop UI works but suffers from four cumulative problems:
+
+1. **Wordy and instructional.** Headings such as "Rename your folders in three steps" plus per-step paragraphs of explanation crowd out the actual interface.
+2. **Cluttered rail.** The left-side stepper currently uses three large cards with title + description + status badge, taking ~280px of horizontal space per step.
+3. **Visual hierarchy is unclear.** Full-width orange primary buttons appear next to every path field, giving equal visual weight to "browse" and "commit", and crowding the canvas.
+4. **Overspecification.** Users must pick a save folder and plan filename even though sensible defaults exist (save next to the photos, name the file `rename-plan.json`).
+
+## Selected direction
+
+From four wireframe directions explored, the chosen approach is **Direction B: thin numbered rail with vertical stacked-letter labels**, with the supporting decisions from Directions A, C, and D folded in where they apply to specific surfaces:
+
+- **Rail** — collapses from 280px-wide cards to a ~70px column. Each step is a numbered circular indicator (1 / 2 / 3) with state (done / now / next / error) and a vertical label drawn as a stack of single-letter `Label`s (e.g. `P / L / A / N`).
+- **Buttons** — full-width orange primary buttons next to path fields are replaced by small inline icon-sized browse buttons. The accent-colored primary is reserved for the single commit action of each screen (`Build plan`, `Continue`, `Rename N folders`).
+- **Defaults** — save folder and plan filename are no longer required user input. The view defaults `OutputDirectoryPath` to the chosen `RootPath`, and `PlanFileName` to `rename-plan.json`. Both fields are hidden behind an `Advanced ▾` disclosure, surfaced only when the user wants to override.
+- **Plan items** — the preview list becomes a vertical list of self-contained cards. Each card has from→to in monospace, a status pill on the right, and is bordered as a single bounded surface — no labels floating above loose values.
+- **Stat strip** — the "Created / Folder changes / Things to note" trio collapses to a small horizontal stat strip (count + label per stat) sitting directly above the plan-item list.
+- **Theme toggle** — three `RadioButton`s collapse to a single icon-pill control that cycles Light → Dark → System on tap and announces the current mode in its tooltip.
+- **Page title** — "Rename your folders in three steps" shrinks. The H1 in the header bar just says "Renamer"; the active step name is shown by the workspace itself.
+
+## Voice
+
+Friendly but minimal. Each piece of UI says one thing. Avoid second-person instructional sentences when a label and a button can carry the same meaning. The exact key-by-key copy already lives in `AppStrings.resx` after slices 300/310/320/330 — this baseline does not re-litigate strings, but each implementation slice may add small new keys (e.g. `AdvancedDisclosureLabel`) which must follow the same voice.
+
+## Vertical labels
+
+The rail's per-step labels (`PLAN`, `PREVIEW`, `RENAME`) are rendered as **stacked single-letter `Label`s in a `VerticalStackLayout`** — not via `Rotation="-90"`. This keeps text crisp at small sizes, supports localization (the resource value is split per character at bind time, or pre-split by the ViewModel into a string list), and avoids antialiasing issues seen with rotated MAUI `Label`s on Windows.
+
+Localization note: this works for Latin scripts but assumes one glyph per character. If/when the project ships in a language with combining characters or vertical-by-default scripts, the rail label binding will need to switch from per-char split to a layout strategy chosen by the active culture. That is **out of scope for v1** but called out here so it surfaces in any future locale work.
+
+## Implementation slice map
+
+| Slice | Type | What it owns |
+|---|---|---|
+| `340` | `refactor(ui)` | Thin numbered rail — replace card-style steps with circular numbered indicator + stacked-letter vertical label. Rail column width drops from 280px to ~70px. |
+| `350` | `refactor(ui)` | Inline icon-sized browse buttons. Remove full-width primary buttons next to path fields; primary accent reserved for commit actions. |
+| `360` | `feat(ui)` | Smart defaults for plan file. Save folder defaults to root folder, filename defaults to `rename-plan.json`, both behind an `Advanced ▾` disclosure. |
+| `370` | `refactor(ui)` | Plan items as bounded cards. Restructure preview list rows into self-contained from→to cards with a status pill. |
+| `380` | `refactor(ui)` | Stat strip + condensed apply-result banner. Replace "Before you rename" trio + Apply detail grid with compact summary blocks. |
+| `390` | `refactor(ui)` | Compact theme toggle. Three `RadioButton`s collapse to a single icon-pill cycling Light/Dark/System; menu bar item kept for parity. |
+
+Slices are independent enough to land in any order after `340`, but the recommended order matches the table.
+
+## References
+
+- Wireframe artifact (low-fi, four directions explored): `Renamer wireframes.html` in the design workspace.
+- Current rail implementation: `src/Renamer.UI/Views/WorkflowRailView.xaml`.
+- Current step model: `src/Renamer.UI/Plans/PlanWorkflowStepItem.cs`, `PlanWorkflowStep.cs`, `PlanWorkflowStepStatus.cs`.
+- Stepper-shell origin: `docs/specs/260-maui-stepper-shell.md`.
+- Copy voice baseline: `docs/specs/300-ui-copy-baseline.md`.

--- a/docs/specs/340-thin-rail-redesign.md
+++ b/docs/specs/340-thin-rail-redesign.md
@@ -1,0 +1,110 @@
+# 340 Thin Rail Redesign
+
+## Slice ID
+`340-thin-rail-redesign`
+
+## Goal
+Replace the full-card workflow rail with a thin numbered-indicator rail that uses a circular step number, an explicit visual state (done / now / next / error), and a vertical stacked-letter step label, freeing horizontal space for the active workspace.
+
+## In scope
+- Rewrite `src/Renamer.UI/Views/WorkflowRailView.xaml` so each step is rendered as:
+  - A circular numbered indicator (~32–36px diameter) showing the step number, with `VisualStateManager` (or `DataTrigger`) variants for `Done`, `Now`, `Next`, and `Error`.
+  - A vertical label rendered as a stack of single-character `Label`s (e.g. `P / L / A / N`) in a `VerticalStackLayout`, sourced from `PlanWorkflowStepItem.Title`.
+  - A short connector line (`BoxView`) between adjacent indicators.
+  - The whole step is still tappable (existing `TapGestureRecognizer` + `SelectStepCommand` preserved).
+- Update `src/Renamer.UI/MainPage.xaml` so the rail column width drops from `280` to `72`.
+- Add a derived property on `PlanWorkflowStepItem` that exposes the title as `IReadOnlyList<string>` (one element per character) for binding to a `BindableLayout`-backed `VerticalStackLayout`. Naming suggestion: `TitleCharacters`.
+- Preserve current state semantics:
+  - `IsSelected = true` ⇒ visual state `Now` (orange/accent fill).
+  - `Status = Done` ⇒ visual state `Done` (success fill, checkmark glyph instead of number).
+  - `Status = Error` ⇒ visual state `Error` (warning stroke, number kept).
+  - Otherwise ⇒ visual state `Next` (outline only, muted text).
+- Update affected XAML-bound resources in `Resources/Themes/*.xaml` if a new color key is required (e.g. `RailIndicatorBackgroundActive`, `RailIndicatorBackgroundDone`); reuse existing keys where possible.
+
+## Out of scope
+- Any change to `IPlanViewModel` step selection logic, `SelectStepCommand`, or `PlanWorkflowStep` enum values.
+- Workspace-side layout changes (Generate / Preview / Apply views).
+- Browse-button restyling (slice `350`).
+- Defaults / Advanced disclosure (slice `360`).
+- Plan item card redesign (slice `370`).
+- Theme toggle compaction (slice `390`).
+- Localization-aware vertical labels for non-Latin scripts (called out in `335`; deferred).
+- Mobile/tablet layouts.
+
+## Dependency notes
+- Depends on `260-maui-stepper-shell.md` (existing rail + step model).
+- Depends on the design decisions in `335-ui-cleanup-design-baseline.md`.
+- Should not regress copy decisions from `300/310/320/330` — all displayed text continues to come from `AppStrings.resx`.
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean:
+   - `git status --short` returns no changes.
+2. Verify current branch is `main`:
+   - `git branch --show-current` returns `main`.
+3. Update local `main` from origin:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main` with required prefix:
+   - `git switch -c refactor/340-thin-rail-redesign`
+5. Confirm branch naming matches this slice ID:
+   - `git branch --show-current` equals `refactor/340-thin-rail-redesign`.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit code until steps 1–6 are complete.
+
+## Implementation steps
+1. Add `TitleCharacters` (or equivalently named) read-only property to `PlanWorkflowStepItem` that returns the step title split into per-character strings. Trim whitespace and uppercase the result for consistent display. Notify on change only if `Title` ever becomes mutable (currently it does not).
+2. Rewrite `WorkflowRailView.xaml` to render each step as `[indicator] [vertical-letter-label]` inside a `VerticalStackLayout` of three steps separated by short connector lines. Apply a `Style`-driven approach to indicator visuals using `VisualStateManager` keyed off a step-state string, or `DataTrigger`s keyed off `IsSelected` and `Status`.
+3. Update `MainPage.xaml` `ColumnDefinitions` for the main grid: `72,*` instead of `280,*`. Adjust `Padding` / `Margin` only as needed to keep the workspace content from butting against the rail.
+4. Audit `Resources/Themes/*.xaml` for color keys used by the existing rail; either reuse them or add minimally-named new keys (`RailIndicatorBackgroundActive`, etc.) and update both `Light` and `Dark` themes.
+5. Add or update `src/Renamer.Tests/UI/*Stepper*` (or a new `WorkflowRailItemTests.cs`) to cover:
+   - `TitleCharacters` returns one entry per character of the trimmed/uppercased title.
+   - State→indicator mapping is correct for combinations of `IsSelected` and `Status`.
+6. Visually verify on Windows (and macOS if available) that the rail is ~72px wide, indicators are circular, and the stacked letters read correctly.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build src/Renamer.UI/Renamer.UI.csproj`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~Stepper|FullyQualifiedName~WorkflowRail"`
+4. `dotnet build Renamer.sln`
+5. `dotnet test Renamer.sln`
+
+## Git/PR workflow
+1. Branch from current `main` using the conventional commit type prefix `refactor/`.
+2. Keep the PR scoped to the rail rewrite, the supporting `PlanWorkflowStepItem` property, the column width change in `MainPage.xaml`, theme color keys, and the related tests.
+3. Title the PR with a Conventional Commit, for example `refactor(ui): 340 thin numbered rail`.
+4. Link the matching issue with `Closes #<issue-number>` when the slice is complete.
+
+## Acceptance checks
+- The desktop UI shows a vertical rail roughly 72px wide on the left with three numbered circular indicators and stacked-letter step labels.
+- The active step's indicator is filled with the accent color; completed steps show a checkmark on a success fill; future steps are outlined in muted color.
+- Tapping a rail step still selects that step and swaps the right-hand workspace, matching prior behavior.
+- All step titles continue to be sourced from `AppStrings.resx` — no hard-coded English in `WorkflowRailView.xaml`.
+- The right-hand workspace gains horizontal space (column width changed from 280 to 72) without overflowing.
+
+## Tests
+- New or updated `src/Renamer.Tests/UI/WorkflowRailItemTests.cs` covering `TitleCharacters` derivation.
+- Updated `src/Renamer.Tests/UI/*Stepper*.cs` if existing tests assert on the old card layout structure (they should not — these are ViewModel-level — but verify).
+
+## Test scope
+- `PlanWorkflowStepItem.TitleCharacters` derivation.
+- Existing stepper selection / status mapping tests must still pass unchanged.
+
+## Expected outputs
+- `src/Renamer.UI/Views/WorkflowRailView.xaml` — rewritten.
+- `src/Renamer.UI/Plans/PlanWorkflowStepItem.cs` — new `TitleCharacters` property.
+- `src/Renamer.UI/MainPage.xaml` — column width updated.
+- `src/Renamer.UI/Resources/Themes/Light.xaml` and `Dark.xaml` — color key updates if required.
+- `src/Renamer.Tests/UI/WorkflowRailItemTests.cs` — new tests covering the derived property and state mapping.
+
+## Exit criteria
+- The rail visually matches the thin-numbered-rail direction in `335-ui-cleanup-design-baseline.md`.
+- Stepper behavior (selection, status badges) is unchanged at the ViewModel level.
+
+## Definition of Done
+- Acceptance checks in this slice are satisfied.
+- Tests listed in this slice are implemented and pass locally.
+- Standard command sequence (`restore` / `build` / `test`) passes.
+- Checklist item for this slice is updated.
+- Branch pre-implementation gate completed before first code edit.
+- Branch name follows `refactor/` and maps to this slice ID.
+- PR scope is limited to this slice (no unrelated refactors).
+- If a matching GitHub issue exists, it is linked from the PR and moved to `In Progress` when the slice is picked up.

--- a/docs/specs/350-inline-browse-buttons.md
+++ b/docs/specs/350-inline-browse-buttons.md
@@ -1,0 +1,83 @@
+# 350 Inline Browse Buttons
+
+## Slice ID
+`350-inline-browse-buttons`
+
+## Goal
+Demote per-field "browse" actions to small inline icon-sized buttons sitting beside their path fields, reserving the accent-colored primary button style for the single commit action of each screen.
+
+## In scope
+- Update `src/Renamer.UI/Views/GenerateWorkspaceView.xaml` so:
+  - Each path `Entry` (root folder, output folder) lives in a `Grid` with `ColumnDefinitions="*,Auto"` and the browse `Button` sits in column 1 with a constrained width (~36px) and an icon-style label (folder glyph or short text label like "…").
+  - The standalone full-width browse `Button`s are removed.
+  - `GenerateButtonGenerateAndLoad` remains the only accent-colored primary button on this view.
+- Update `src/Renamer.UI/Views/ApplyWorkspaceView.xaml` similarly if any browse / file-picker buttons in that view follow the same full-width pattern (audit during implementation; if none, note it in the PR description).
+- Add a new `BrowseButton` style in `Resources/Styles` (or extend an existing button style) that fixes width, padding, and visual weight so the pattern is reusable.
+- Add a glyph-only string resource if needed (e.g. `BrowseButtonGlyph` = "…" or a folder unicode character) to keep XAML free of hard-coded display text.
+- Reuse the existing `Browse` resource keys (`GenerateBrowseRootFolder`, `GenerateBrowseOutputFolder`) for the button's `AutomationProperties.Name` / `ToolTipProperties.Text` so the action is still announced to assistive tech.
+
+## Out of scope
+- Default-folder behavior or `Advanced ▾` disclosure (slice `360`).
+- Plan item card redesign (slice `370`).
+- Theme / color tokens beyond what the new button style needs.
+- Any change to the picker services (`IFolderPathPicker`, `IPlanFilePicker`) or the underlying commands.
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean:
+   - `git status --short` returns no changes.
+2. Verify current branch is `main`:
+   - `git branch --show-current` returns `main`.
+3. Update local `main` from origin:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main` with required prefix:
+   - `git switch -c refactor/350-inline-browse-buttons`
+5. Confirm branch naming matches this slice ID:
+   - `git branch --show-current` equals `refactor/350-inline-browse-buttons`.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit code until steps 1–6 are complete.
+
+## Implementation steps
+1. Add `BrowseButton` style to `src/Renamer.UI/Resources/Styles/` (or the existing styles file). Constrain width, padding, and visual weight; ensure it inherits the standard button base style for hover/focus consistency.
+2. Refactor each path field block in `GenerateWorkspaceView.xaml` from a vertical stack `[Label][Entry][Button]` into `[Label]` + `Grid("*,Auto")` containing `[Entry][BrowseButton]`. Apply the new style. Bind `AutomationProperties.Name` and `ToolTipProperties.Text` to the existing `Browse*` resource keys.
+3. Add `BrowseButtonGlyph` (or equivalent) to `AppStrings.resx` if a textual glyph is used. Regenerate `AppStrings.Designer.cs`.
+4. Audit `ApplyWorkspaceView.xaml` for any browse buttons that fit the same pattern; apply the same restructure or note in PR that no changes were needed.
+5. Visually verify the only accent-colored primary button on each screen is the commit action.
+6. Update or add tests if any UI test asserts on the prior button arrangement (likely none; verify).
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build src/Renamer.UI/Renamer.UI.csproj`
+3. `dotnet build Renamer.sln`
+4. `dotnet test Renamer.sln`
+
+## Git/PR workflow
+1. Branch from current `main` using the conventional commit type prefix `refactor/`.
+2. Keep the PR scoped to button-style restructuring on the affected views and the supporting style/resource additions.
+3. Title the PR with a Conventional Commit, for example `refactor(ui): 350 inline browse buttons`.
+4. Link the matching issue with `Closes #<issue-number>` when the slice is complete.
+
+## Acceptance checks
+- Each path `Entry` on the Generate workspace has a small inline browse button to its right; no full-width browse button remains.
+- The Generate workspace shows exactly one accent-colored primary button: the commit action (`GenerateButtonGenerateAndLoad`).
+- Browse buttons announce a name to assistive tech via `AutomationProperties.Name` from the existing `Browse*` resource keys.
+- Apply workspace either follows the same pattern or the PR confirms no change was needed there.
+- Browse, generate, and apply commands continue to fire correctly.
+
+## Tests
+- No new behavioral tests required. If any existing UI test asserts on the old button layout, update it.
+
+## Test scope
+- Standard `restore` / `build` / `test` must pass.
+
+## Expected outputs
+- `src/Renamer.UI/Views/GenerateWorkspaceView.xaml` — updated.
+- `src/Renamer.UI/Views/ApplyWorkspaceView.xaml` — updated if applicable.
+- `src/Renamer.UI/Resources/Styles/*.xaml` — new `BrowseButton` style.
+- `src/Renamer.UI/Resources/Strings/AppStrings.resx` (+ Designer) — new glyph key if used.
+
+## Definition of Done
+- Acceptance checks in this slice are satisfied.
+- Standard command sequence passes locally.
+- Checklist item for this slice is updated.
+- Branch pre-implementation gate completed before first code edit.
+- PR scope limited to this slice.

--- a/docs/specs/360-plan-file-smart-defaults.md
+++ b/docs/specs/360-plan-file-smart-defaults.md
@@ -1,0 +1,98 @@
+# 360 Plan File Smart Defaults
+
+## Slice ID
+`360-plan-file-smart-defaults`
+
+## Goal
+Stop forcing the user to specify a save folder and plan filename for the common case. Default the output folder to the chosen photo folder, default the filename to `rename-plan.json`, and hide both fields behind an `Advanced ▾` disclosure that only matters when the user wants to override.
+
+## In scope
+- Update `Renamer.UI.Plans.PlanViewModel`:
+  - When `GenerationRootPath` changes and the user has not explicitly set `GenerationOutputDirectoryPath`, default the output directory to the root path.
+  - Default `PlanFileName` to `rename-plan.json` when not set.
+  - Track whether the user has overridden either default (so that further root-path changes do not stomp a user-chosen output path).
+  - Surface a single boolean property `HasAdvancedOverrides` (true when either default has been overridden) for the disclosure to bind to.
+- Update `src/Renamer.UI/Views/GenerateWorkspaceView.xaml`:
+  - Wrap the output-folder + filename + computed-path-preview block in a collapsible region (e.g. an `Expander` if available in the project's MAUI toolkit, otherwise a `Button` toggling `IsVisible` on a `VerticalStackLayout`).
+  - Default the disclosure to collapsed.
+  - Auto-expand when `HasAdvancedOverrides` is true (e.g. after the user opens it once and edits a value).
+  - Add a small helper `Label` showing the resolved plan-save location in collapsed state, e.g. "Plan will be saved beside your photos."
+- Add new resource keys to `AppStrings.resx`:
+  - `GenerateAdvancedDisclosureLabel` — e.g. `Advanced`
+  - `GenerateAdvancedDisclosureHelpCollapsed` — e.g. `Plan will be saved beside your photos.`
+  - `DefaultPlanFileName` — `rename-plan.json` (referenced by the ViewModel default; living in resx so the default file *name* is localizable even though the default value is the same in English).
+- Update tests:
+  - ViewModel default behavior: setting `GenerationRootPath` updates `GenerationOutputDirectoryPath` only when not overridden.
+  - Filename defaults to `rename-plan.json` when no value supplied.
+  - Override flags transition correctly.
+
+## Out of scope
+- Visual restyling of the disclosure beyond the simple show/hide pattern.
+- Plan item card redesign (`370`).
+- Validation rule changes for output folder / plan file (no behavior change in success/error cases beyond defaulting).
+- Persisting overrides across app launches.
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean:
+   - `git status --short` returns no changes.
+2. Verify current branch is `main`:
+   - `git branch --show-current` returns `main`.
+3. Update local `main` from origin:
+   - `git pull --ff-only origin main`
+4. Create the slice branch from `main` with required prefix:
+   - `git switch -c feat/360-plan-file-smart-defaults`
+5. Confirm branch naming matches this slice ID:
+   - `git branch --show-current` equals `feat/360-plan-file-smart-defaults`.
+6. If a matching GitHub issue exists, move it to `In Progress` and confirm it matches this slice ID.
+7. Do not edit code until steps 1–6 are complete.
+
+## Implementation steps
+1. Introduce internal flags on `PlanViewModel` (e.g. `outputDirectoryPathOverridden`, `planFileNameOverridden`) set to `true` only when the *user* changes the value via UI binding (not when the ViewModel writes the default itself).
+2. Implement default-on-change for output directory: when `GenerationRootPath` setter runs and `outputDirectoryPathOverridden == false`, copy the new root to `GenerationOutputDirectoryPath` silently (using a private setter path that does not flip the override flag).
+3. Initialize `PlanFileName` to `rename-plan.json` (sourced from `AppStrings.DefaultPlanFileName`) on construction; flip `planFileNameOverridden` on user write.
+4. Expose `HasAdvancedOverrides` as a derived property; raise change notifications when either underlying flag changes.
+5. Update `GenerateWorkspaceView.xaml` to wrap the override-only fields in a disclosure. Bind `IsVisible` of the inner stack to a local toggle (`IsAdvancedExpanded`) initialized from `HasAdvancedOverrides`. Show a compact summary line in collapsed state.
+6. Add resource keys to `AppStrings.resx`; regenerate `AppStrings.Designer.cs`.
+7. Update / add ViewModel tests covering the default + override behavior.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build Renamer.sln`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~PlanViewModel"`
+4. `dotnet test Renamer.sln`
+
+## Git/PR workflow
+1. Branch from current `main` using the conventional commit type prefix `feat/`. (User-visible behavior change: defaulting fields and hiding inputs.)
+2. Keep the PR scoped to ViewModel default logic, the Generate view disclosure, and the supporting resource keys + tests.
+3. Title the PR with a Conventional Commit, for example `feat(ui): 360 plan file smart defaults`.
+4. Link the matching issue with `Closes #<issue-number>` when the slice is complete.
+
+## Acceptance checks
+- On a fresh launch, picking a photo folder no longer requires picking a save folder or typing a filename — the user can press the commit action immediately and a plan file is produced beside the photos.
+- The output folder + filename + plan-path-preview block is hidden by default behind `Advanced ▾`.
+- Expanding `Advanced ▾` and editing either value sticks: subsequent root-path changes do not overwrite the user-supplied output folder.
+- Collapsed state shows a short helper line indicating where the plan will be saved.
+- All new copy comes from `AppStrings.resx`.
+
+## Tests
+- New `src/Renamer.Tests/UI/PlanViewModelDefaultsTests.cs` (or extend `PlanViewModelTests.cs`):
+  - Default plan filename is `rename-plan.json`.
+  - Setting `GenerationRootPath` updates `GenerationOutputDirectoryPath` to match when not overridden.
+  - User-supplied output directory is preserved across subsequent root-path changes.
+  - `HasAdvancedOverrides` reflects override state.
+
+## Test scope
+- ViewModel default + override behavior. No filesystem IO required.
+
+## Expected outputs
+- `src/Renamer.UI/Plans/PlanViewModel.cs` — defaults + override flags + derived property.
+- `src/Renamer.UI/Views/GenerateWorkspaceView.xaml` — `Advanced ▾` disclosure.
+- `src/Renamer.UI/Resources/Strings/AppStrings.resx` (+ Designer) — new keys.
+- `src/Renamer.Tests/UI/PlanViewModelDefaultsTests.cs` — new tests.
+
+## Definition of Done
+- Acceptance checks in this slice are satisfied.
+- Tests pass locally.
+- Checklist item for this slice is updated.
+- Branch pre-implementation gate completed before first code edit.
+- PR scope limited to this slice.

--- a/docs/specs/370-plan-items-as-cards.md
+++ b/docs/specs/370-plan-items-as-cards.md
@@ -1,0 +1,75 @@
+# 370 Plan Items as Cards
+
+## Slice ID
+`370-plan-items-as-cards`
+
+## Goal
+Restructure the preview list so each proposed folder rename is a single bounded card with a clear from→to pair and a status pill, replacing the current row layout where labels and values float independently.
+
+## In scope
+- Update `src/Renamer.UI/Views/PreviewWorkspaceView.xaml` so the `CollectionView` (or equivalent) `ItemTemplate` for `PlanOperationItem` renders:
+  - A `Border` with rounded corners as the card surface.
+  - A two-line stack: the original folder name in monospace muted text on top, the proposed new name in monospace primary text on the second line.
+  - A status pill on the right (color-coded by `PlanOperationItem` state — ok / warning / conflict / skipped, etc., matching the existing operation states).
+  - Item spacing of 8–12px between cards.
+- Add or extend a `PlanOperationCard` style in `Resources/Styles`.
+- If `PlanOperationItem` lacks display-friendly properties for the from/to pair or the status pill text/color, add derived properties on the item (e.g. `FromDisplay`, `ToDisplay`, `StatusPillText`, `StatusPillColor`).
+- Keep all displayed text sourced from `AppStrings.resx` where applicable; the from/to values themselves remain data.
+
+## Out of scope
+- Stat strip / "Before you rename" replacement (slice `380`).
+- Apply-result row redesign (slice `380`).
+- Any change to plan generation, conflict logic, or the underlying `PlanOperationItem` semantics beyond adding display-derived properties.
+- Selection / bulk-action UI on the card (deferred).
+
+## Pre-implementation gate (must pass before code edits)
+1. Verify working tree is clean.
+2. Verify current branch is `main`.
+3. Update local `main` from origin.
+4. `git switch -c refactor/370-plan-items-as-cards`.
+5. Confirm branch name.
+6. Move matching GitHub issue to `In Progress` if present.
+7. Do not edit code until steps 1–6 are complete.
+
+## Implementation steps
+1. Audit `PlanOperationItem` for existing display fields. Add `FromDisplay`, `ToDisplay`, `StatusPillText`, `StatusPillColor` if missing — derived from existing state.
+2. Write `PlanOperationCard` style (background, border, corner radius, padding) in `Resources/Styles`.
+3. Rewrite the `ItemTemplate` in `PreviewWorkspaceView.xaml` to use the new card layout: `Grid("*,Auto")` with the from/to stack on the left and the status pill on the right.
+4. Ensure the card surface respects existing theme color keys (light/dark) — add new keys only if needed.
+5. Add unit tests for the new derived properties on `PlanOperationItem` covering each operation state.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build Renamer.sln`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~PlanOperation|FullyQualifiedName~Preview"`
+4. `dotnet test Renamer.sln`
+
+## Git/PR workflow
+1. Branch from `main` with prefix `refactor/`.
+2. Keep PR scoped to preview list restructuring and supporting derived properties + tests.
+3. PR title: `refactor(ui): 370 plan items as cards`.
+4. Link matching issue with `Closes #<issue-number>`.
+
+## Acceptance checks
+- Each proposed folder rename in the preview is shown as a single bounded card.
+- The card shows the original name above the proposed name, both in monospace, with the proposed name visually dominant.
+- Each card has a status pill on the right whose color and text reflect the operation state.
+- Light and dark themes both render cards legibly.
+- No regressions in plan generation, loading, or preview population.
+
+## Tests
+- `src/Renamer.Tests/Plans/PlanOperationItemDisplayTests.cs` (new) covering each operation state's pill text + color and the from/to display strings.
+- Existing preview / plan loading tests must continue to pass.
+
+## Expected outputs
+- `src/Renamer.UI/Plans/PlanOperationItem.cs` — display-derived properties added.
+- `src/Renamer.UI/Views/PreviewWorkspaceView.xaml` — card-based item template.
+- `src/Renamer.UI/Resources/Styles/*.xaml` — `PlanOperationCard` style.
+- `src/Renamer.Tests/Plans/PlanOperationItemDisplayTests.cs` — new tests.
+
+## Definition of Done
+- Acceptance checks satisfied.
+- Tests pass.
+- Checklist updated.
+- Pre-implementation gate completed.
+- PR scope limited to this slice.

--- a/docs/specs/380-stat-strip-and-result-banner.md
+++ b/docs/specs/380-stat-strip-and-result-banner.md
@@ -1,0 +1,81 @@
+# 380 Stat Strip and Result Banner
+
+## Slice ID
+`380-stat-strip-and-result-banner`
+
+## Goal
+Replace the verbose "Before you rename" (Created / Folder changes / Things to note) trio on the Preview workspace and the detailed Result / Started / Finished / Success / Skipped / Failed grid on the Apply workspace with compact stat-strip / banner summaries that lead with the headline number and tuck supporting details out of the way.
+
+## In scope
+- Preview workspace:
+  - Replace the three "Before you rename" cards in `PreviewWorkspaceView.xaml` with a horizontal stat strip: small bordered tiles each showing a count + a short label (e.g. "2 changes", "0 notes").
+  - If only one stat is non-zero, the strip should still render uniformly — no special-casing.
+- Apply workspace:
+  - Replace the detail grid in `ApplyWorkspaceView.xaml` with a single result banner: large headline (e.g. "Renamed 2 folders") and a one-line breakdown ("0 skipped · 0 failed").
+  - Move start / finish timestamps and any other diagnostic detail behind a `Details ▾` disclosure (collapsed by default).
+- Add display-derived properties on `PlanViewModel` if needed (e.g. `PreviewStatChanges`, `PreviewStatNotes`, `ApplyResultHeadline`, `ApplyResultBreakdown`).
+- Update `AppStrings.resx` with shorter labels:
+  - `PreviewStatChangesLabel` — e.g. `changes`
+  - `PreviewStatNotesLabel` — e.g. `notes`
+  - `ApplyResultHeadlineFormat` — e.g. `Renamed {0} folders` (with singular handling — see below)
+  - `ApplyResultBreakdownFormat` — e.g. `{0} skipped · {1} failed`
+  - `ApplyResultDetailsDisclosure` — e.g. `Details`
+- Pluralization: use a small format helper or two resource keys (`...HeadlineSingular` / `...HeadlinePlural`) — pick one approach in implementation and stay consistent.
+
+## Out of scope
+- Plan item card redesign (`370`).
+- Failure-mode messaging changes (covered by `330`).
+- Persisting "Details ▾" expansion across launches.
+
+## Pre-implementation gate (must pass before code edits)
+1. Working tree clean.
+2. On `main`.
+3. `git pull --ff-only origin main`.
+4. `git switch -c refactor/380-stat-strip-and-result-banner`.
+5. Confirm branch.
+6. Move matching issue to `In Progress`.
+7. No code edits until steps 1–6 complete.
+
+## Implementation steps
+1. Audit `PlanViewModel` for existing summary fields. Add display-derived properties for the stat strip and result banner where missing.
+2. Decide pluralization approach (format helper vs. dual resource keys). Document choice in PR description.
+3. Update `PreviewWorkspaceView.xaml` to render the stat strip in place of the existing trio.
+4. Update `ApplyWorkspaceView.xaml` to render the result banner; wrap the prior detail grid in a `Details ▾` disclosure.
+5. Add resource keys to `AppStrings.resx`; regenerate Designer.
+6. Add ViewModel tests for the new derived properties (zero, single, plural cases).
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build Renamer.sln`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~PlanViewModel|FullyQualifiedName~ApplyFlow"`
+4. `dotnet test Renamer.sln`
+
+## Git/PR workflow
+1. Branch with prefix `refactor/`.
+2. PR scoped to preview/apply summary restructuring + supporting properties/tests.
+3. PR title: `refactor(ui): 380 stat strip and result banner`.
+4. Link issue with `Closes #<issue-number>`.
+
+## Acceptance checks
+- The Preview workspace shows a horizontal stat strip instead of three full cards.
+- The Apply workspace shows a single headline + one-line breakdown, with full details available behind `Details ▾`.
+- Pluralization reads correctly for 0, 1, and >1 in each stat.
+- All copy is sourced from `AppStrings.resx`.
+- No regressions in apply / preview behavior.
+
+## Tests
+- `src/Renamer.Tests/UI/PlanViewModelSummaryTests.cs` (new or extended): cover headline + breakdown derivation including plural cases.
+
+## Expected outputs
+- `src/Renamer.UI/Plans/PlanViewModel.cs` — derived summary properties.
+- `src/Renamer.UI/Views/PreviewWorkspaceView.xaml` — stat strip.
+- `src/Renamer.UI/Views/ApplyWorkspaceView.xaml` — result banner + `Details ▾` disclosure.
+- `src/Renamer.UI/Resources/Strings/AppStrings.resx` (+ Designer) — new keys.
+- `src/Renamer.Tests/UI/PlanViewModelSummaryTests.cs` — tests.
+
+## Definition of Done
+- Acceptance checks satisfied.
+- Tests pass.
+- Checklist updated.
+- Pre-implementation gate completed.
+- PR scope limited to this slice.

--- a/docs/specs/390-compact-theme-toggle.md
+++ b/docs/specs/390-compact-theme-toggle.md
@@ -1,0 +1,81 @@
+# 390 Compact Theme Toggle
+
+## Slice ID
+`390-compact-theme-toggle`
+
+## Goal
+Replace the three-`RadioButton` Light/Dark/System group in the page header with a single compact icon-pill control that cycles through the three modes on tap and announces the current mode to assistive tech.
+
+## In scope
+- Replace the `Border` + `HorizontalStackLayout` of three `RadioButton`s in `MainPage.xaml` with a single tappable control:
+  - Visual: a small pill (~80–100px wide) with a sun, moon, or auto glyph depending on current mode, plus the mode name label.
+  - Tap cycles Light → Dark → System → Light.
+  - Tooltip / `AutomationProperties.Name` reads the current mode in the form `Theme: <mode>`.
+- Keep the `View` `MenuFlyoutItem` entries (`OnLightThemeClicked` / `OnDarkThemeClicked` / `OnSystemThemeClicked`) as-is for menu-bar parity.
+- Update `ThemeService` to expose:
+  - A `CurrentTheme` property (existing or new).
+  - A `CycleTheme()` method that advances Light → Dark → System.
+- Update `MainPage.xaml.cs` to wire the new control's tap to `ThemeService.CycleTheme()` and to update the visual on `CurrentTheme` changes.
+- Add resource keys to `AppStrings.resx`:
+  - `ThemeToggleLight` — `Light`
+  - `ThemeToggleDark` — `Dark`
+  - `ThemeToggleSystem` — `System`
+  - `ThemeToggleAccessibilityFormat` — `Theme: {0}` (used for `AutomationProperties.Name`).
+
+## Out of scope
+- Removing the `View` menu bar entries.
+- Theme color token changes.
+- Persisting theme across launches (assume already handled).
+
+## Pre-implementation gate (must pass before code edits)
+1. Working tree clean.
+2. On `main`.
+3. `git pull --ff-only origin main`.
+4. `git switch -c refactor/390-compact-theme-toggle`.
+5. Confirm branch.
+6. Move matching issue to `In Progress`.
+7. No code edits until steps 1–6 complete.
+
+## Implementation steps
+1. Add `CycleTheme()` to `ThemeService` (and any required `CurrentTheme` getter / event). Cover with unit tests.
+2. Replace the three-`RadioButton` block in `MainPage.xaml` with a tappable `Border` containing a small icon glyph and label, bound to `ThemeService.CurrentTheme`.
+3. Wire `TapGestureRecognizer` (or `Button` styled as a pill) to `CycleTheme()`. Refresh the visual on theme change.
+4. Bind `AutomationProperties.Name` and `ToolTipProperties.Text` via `ThemeToggleAccessibilityFormat`.
+5. Remove no-longer-used `OnThemeRadioChanged` handler if redundant; keep it if menu-bar parity still needs it.
+6. Add tests for `ThemeService.CycleTheme()` ordering.
+
+## Commands to run
+1. `dotnet restore Renamer.sln`
+2. `dotnet build Renamer.sln`
+3. `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~Theme"`
+4. `dotnet test Renamer.sln`
+
+## Git/PR workflow
+1. Branch with prefix `refactor/`.
+2. PR scoped to header theme control + service cycling logic + tests.
+3. PR title: `refactor(ui): 390 compact theme toggle`.
+4. Link issue with `Closes #<issue-number>`.
+
+## Acceptance checks
+- The page header shows a single compact theme control, not three radio buttons.
+- Tapping cycles Light → Dark → System → Light and the visual updates immediately.
+- Assistive tech announces the current mode via `AutomationProperties.Name`.
+- The `View` menu bar still exposes the three explicit theme choices.
+- All new copy is sourced from `AppStrings.resx`.
+
+## Tests
+- `src/Renamer.Tests/UI/ThemeServiceTests.cs` (new or extended) covering `CycleTheme()` ordering across all three modes.
+
+## Expected outputs
+- `src/Renamer.UI/Services/ThemeService.cs` — `CycleTheme()` + `CurrentTheme`.
+- `src/Renamer.UI/MainPage.xaml` — compact theme control replaces the radio group.
+- `src/Renamer.UI/MainPage.xaml.cs` — wiring updated.
+- `src/Renamer.UI/Resources/Strings/AppStrings.resx` (+ Designer) — new keys.
+- `src/Renamer.Tests/UI/ThemeServiceTests.cs` — tests.
+
+## Definition of Done
+- Acceptance checks satisfied.
+- Tests pass.
+- Checklist updated.
+- Pre-implementation gate completed.
+- PR scope limited to this slice.

--- a/docs/specs/mockups/Renamer hi-fi.html
+++ b/docs/specs/mockups/Renamer hi-fi.html
@@ -1,0 +1,278 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Renamer — hi-fi mocks (slice 340)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; font-family: 'Inter', system-ui, sans-serif; }
+
+  /* === Renamer light + dark theme tokens (mirrored from LightTheme.xaml / DarkTheme.xaml) === */
+  .rn-light {
+    --bg-1: #F8FAFC; --bg-2: #FFFFFF; --bg-3: #F0F4F8;
+    --accent-1: #854F0B; --accent-mid: #D97706; --accent-light: #B45309;
+    --text-1: #1E293B; --text-2: #475569; --text-muted: #5C5C5C; --text-link: #0F4C81;
+    --btn-bg: #D97706; --btn-text: #FFFFFF;
+    --border: #CBD5E1; --badge: #E2E8F0; --divider: #D8D8D8;
+    --status-ok: #166534; --status-err: #9A3412; --status-default: #475569;
+    --rail-bg: #F0F4F8;
+  }
+  .rn-dark {
+    --bg-1: #0D1117; --bg-2: #161B25; --bg-3: #1E2535;
+    --accent-1: #854F0B; --accent-mid: #EF9F27; --accent-light: #FAC775;
+    --text-1: #E8ECF4; --text-2: #A8B4CC; --text-muted: #5A6680; --text-link: #FAC775;
+    --btn-bg: #854F0B; --btn-text: #E8ECF4;
+    --border: #2A3347; --badge: #1E2535; --divider: #2A3347;
+    --status-ok: #166534; --status-err: #9A3412; --status-default: #5A6680;
+    --rail-bg: #161B25;
+  }
+
+  /* === App window shell === */
+  .rn-window {
+    width: 1100px; height: 720px;
+    background: var(--bg-1); color: var(--text-1);
+    display: flex; flex-direction: column;
+    border: 1px solid var(--border);
+    overflow: hidden;
+  }
+  .rn-titlebar {
+    height: 36px; flex: 0 0 36px;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 14px;
+    background: var(--bg-3); border-bottom: 1px solid var(--border);
+    font-size: 12px; color: var(--text-muted);
+  }
+  .rn-titlebar .menu { display: flex; gap: 16px; font-size: 12px; color: var(--text-2); }
+  .rn-titlebar .menu span { cursor: default; }
+
+  .rn-page {
+    flex: 1; min-height: 0;
+    display: grid; grid-template-rows: auto 1fr;
+    padding: 24px; gap: 18px;
+  }
+
+  .rn-header {
+    display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
+  }
+  .rn-title { font-size: 28px; font-weight: 700; letter-spacing: -0.01em; margin: 0; color: var(--text-1); }
+  .rn-sub { font-size: 13px; color: var(--text-muted); margin: 4px 0 0; }
+
+  /* Compact theme pill (the slice-390 preview) */
+  .rn-theme-pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 6px 12px; border: 1px solid var(--border); background: var(--bg-3);
+    border-radius: 8px; font-size: 12px; color: var(--text-2);
+    cursor: default; user-select: none;
+  }
+  .rn-theme-pill .glyph {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: linear-gradient(135deg, #FAC775 50%, #1E2535 50%);
+    border: 1px solid var(--border);
+  }
+  .rn-light .rn-theme-pill .glyph { background: #FAC775; }
+  .rn-dark  .rn-theme-pill .glyph { background: #1E2535; }
+
+  /* === Main grid: thin rail + workspace === */
+  .rn-main { display: grid; grid-template-columns: 72px 1fr; gap: 0; min-height: 0; }
+
+  /* === Thin rail === */
+  .rn-rail {
+    background: var(--bg-2); border: 1px solid var(--border); border-right: none;
+    border-radius: 8px 0 0 8px;
+    padding: 18px 0;
+    display: flex; flex-direction: column; align-items: center; gap: 8px;
+  }
+  .rn-step {
+    display: flex; flex-direction: column; align-items: center; gap: 8px;
+    padding: 8px 0; cursor: default;
+    width: 100%;
+  }
+  .rn-dot {
+    width: 32px; height: 32px; border-radius: 50%;
+    border: 1.5px solid var(--border);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px; font-weight: 600;
+    background: var(--bg-2); color: var(--text-2);
+    font-family: 'JetBrains Mono', monospace;
+  }
+  .rn-dot.done { background: var(--status-ok); border-color: var(--status-ok); color: #fff; }
+  .rn-dot.now  { background: var(--btn-bg); border-color: var(--btn-bg); color: var(--btn-text); box-shadow: 0 0 0 3px color-mix(in srgb, var(--btn-bg) 25%, transparent); }
+  .rn-dot.err  { background: var(--bg-2); border-color: var(--status-err); color: var(--status-err); }
+  .rn-dot.next { color: var(--text-muted); }
+
+  .rn-vlabel {
+    display: flex; flex-direction: column; align-items: center; gap: 1px;
+    font-size: 10px; font-weight: 600; letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    line-height: 1;
+  }
+  .rn-step.is-now .rn-vlabel { color: var(--accent-mid); }
+  .rn-step.is-done .rn-vlabel { color: var(--text-2); }
+
+  .rn-rail-line { width: 1px; height: 24px; background: var(--border); }
+
+  /* === Workspace === */
+  .rn-workspace {
+    background: var(--bg-2); border: 1px solid var(--border);
+    border-radius: 0 8px 8px 0;
+    padding: 22px 24px;
+    overflow: hidden;
+    display: flex; flex-direction: column; gap: 16px;
+  }
+  .rn-ws-head h2 { font-size: 20px; font-weight: 600; margin: 0; color: var(--text-1); }
+  .rn-ws-head .crumbs { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 4px; }
+  .rn-ws-head p { font-size: 13px; color: var(--text-2); margin: 6px 0 0; }
+
+  /* === Form bits === */
+  .rn-field-row { display: grid; grid-template-columns: 100px 1fr auto; gap: 10px; align-items: center; }
+  .rn-field-row .rn-label { font-size: 12px; font-weight: 500; color: var(--text-2); }
+  .rn-input {
+    height: 34px; padding: 0 10px;
+    background: var(--bg-1); border: 1px solid var(--border); border-radius: 6px;
+    font-family: 'JetBrains Mono', monospace; font-size: 12.5px;
+    color: var(--text-1);
+    display: flex; align-items: center;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .rn-input.placeholder { color: var(--text-muted); font-style: italic; }
+  .rn-icon-btn {
+    width: 34px; height: 34px; border: 1px solid var(--border);
+    background: var(--bg-3); color: var(--text-2);
+    border-radius: 6px; display: flex; align-items: center; justify-content: center;
+    cursor: default; font-size: 14px;
+  }
+  .rn-icon-btn:hover { color: var(--text-1); }
+
+  /* === Advanced disclosure === */
+  .rn-advanced {
+    border-top: 1px dashed var(--border);
+    padding-top: 12px; margin-top: 4px;
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .rn-disc-row { display: flex; align-items: center; justify-content: space-between; }
+  .rn-disc-row .hint { font-size: 12px; color: var(--text-muted); }
+  .rn-disc-btn {
+    font-size: 12px; color: var(--text-2);
+    background: transparent; border: 1px solid var(--border);
+    padding: 4px 10px; border-radius: 6px;
+    cursor: default;
+  }
+  .rn-advanced-body {
+    display: flex; flex-direction: column; gap: 10px;
+    padding: 12px; border: 1px solid var(--border); border-radius: 6px;
+    background: var(--bg-1);
+  }
+
+  /* === Buttons === */
+  .rn-btn {
+    height: 36px; padding: 0 18px;
+    border: 1px solid var(--btn-bg); background: var(--btn-bg); color: var(--btn-text);
+    font-size: 13px; font-weight: 600;
+    border-radius: 6px; cursor: default;
+    display: inline-flex; align-items: center; gap: 8px;
+  }
+  .rn-btn.ghost {
+    background: transparent; color: var(--text-2); border-color: var(--border);
+  }
+  .rn-btn.sm { height: 30px; font-size: 12px; padding: 0 12px; }
+  .rn-actions { display: flex; align-items: center; justify-content: space-between; }
+  .rn-actions .meta { font-size: 12px; color: var(--text-muted); }
+  .rn-actions .group { display: flex; gap: 8px; }
+
+  /* === Stat strip === */
+  .rn-stats { display: flex; gap: 10px; flex-wrap: wrap; }
+  .rn-stat {
+    border: 1px solid var(--border); background: var(--bg-1);
+    padding: 8px 14px; border-radius: 6px; min-width: 90px;
+  }
+  .rn-stat .num { font-size: 20px; font-weight: 700; line-height: 1.1; color: var(--text-1); }
+  .rn-stat .lbl { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; margin-top: 2px; }
+
+  /* === Plan cards === */
+  .rn-cards { display: flex; flex-direction: column; gap: 8px; overflow-y: auto; padding-right: 4px; max-height: 340px; }
+  .rn-card {
+    border: 1px solid var(--border); border-radius: 8px; background: var(--bg-1);
+    padding: 12px 14px;
+    display: grid; grid-template-columns: 1fr auto; gap: 4px 12px; align-items: center;
+  }
+  .rn-card .from { font-family: 'JetBrains Mono', monospace; font-size: 11.5px; color: var(--text-muted); text-decoration: line-through; }
+  .rn-card .to { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--text-1); font-weight: 500; }
+  .rn-card.warn { border-color: color-mix(in srgb, var(--status-err) 35%, var(--border)); background: color-mix(in srgb, var(--status-err) 6%, var(--bg-1)); }
+
+  /* === Status pill === */
+  .rn-pill {
+    font-size: 10.5px; font-weight: 600;
+    padding: 3px 9px; border-radius: 999px;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    background: var(--badge); color: var(--text-2);
+    border: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  .rn-pill.ok { background: color-mix(in srgb, var(--status-ok) 18%, var(--bg-1)); color: var(--status-ok); border-color: color-mix(in srgb, var(--status-ok) 40%, var(--border)); }
+  .rn-pill.warn { background: color-mix(in srgb, var(--status-err) 18%, var(--bg-1)); color: var(--status-err); border-color: color-mix(in srgb, var(--status-err) 40%, var(--border)); }
+
+  /* === Apply result banner === */
+  .rn-banner {
+    border: 1px solid var(--border); border-radius: 8px; background: var(--bg-1);
+    padding: 18px 20px;
+    display: flex; flex-direction: column; gap: 4px;
+  }
+  .rn-banner .hl { font-size: 22px; font-weight: 700; color: var(--text-1); display: flex; align-items: center; gap: 10px; }
+  .rn-banner .hl .check {
+    width: 24px; height: 24px; border-radius: 50%;
+    background: var(--status-ok); color: #fff;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 14px;
+  }
+  .rn-banner .breakdown { font-size: 13px; color: var(--text-2); margin-left: 34px; }
+  .rn-banner .details-toggle {
+    margin-top: 10px; align-self: flex-start;
+    font-size: 12px; color: var(--text-2);
+    background: transparent; border: 1px solid var(--border);
+    padding: 4px 10px; border-radius: 6px;
+  }
+
+  /* === Annotation pins === */
+  .anno-pin {
+    position: absolute;
+    background: #1E293B; color: #fff;
+    font-size: 11px; padding: 6px 9px; border-radius: 6px;
+    max-width: 220px; line-height: 1.3;
+    box-shadow: 0 4px 12px rgba(0,0,0,.18);
+    z-index: 10;
+  }
+  .anno-pin b { color: #FAC775; }
+  .anno-pin::before {
+    content: ''; position: absolute;
+    width: 8px; height: 8px; background: inherit;
+    transform: rotate(45deg);
+  }
+  .anno-pin.left::before { left: -4px; top: 50%; margin-top: -4px; }
+  .anno-pin.right::before { right: -4px; top: 50%; margin-top: -4px; }
+  .anno-pin.top::before { top: -4px; left: 20px; }
+
+  /* === Token swatch artboard === */
+  .swatches { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; padding: 24px; background: #fff; }
+  .swatch { border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; }
+  .swatch .chip { height: 56px; }
+  .swatch .meta { padding: 8px 10px; font-size: 11px; }
+  .swatch .meta .name { font-weight: 600; color: #111; }
+  .swatch .meta .hex { font-family: 'JetBrains Mono', monospace; color: #6b7280; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="hifi-mocks-v2.jsx"></script>
+</body>
+</html>

--- a/docs/specs/mockups/Renamer wireframes.html
+++ b/docs/specs/mockups/Renamer wireframes.html
@@ -1,0 +1,374 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Renamer — wireframe directions</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;500;600;700&family=Kalam:wght@300;400;700&family=Architects+Daughter&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<style>
+  :root {
+    --paper: #fbfaf6;
+    --paper-2: #f4f1e8;
+    --ink: #1f1d1a;
+    --ink-2: #4a463e;
+    --ink-soft: #8a8478;
+    --rule: #2a2724;
+    --accent: #c46a2a;
+    --accent-soft: #e9c39a;
+    --good: #4a7a3a;
+    --bad: #b04a2c;
+    --note: #486b9e;
+    --hand-display: 'Caveat', cursive;
+    --hand-body: 'Kalam', cursive;
+    --hand-mono: 'JetBrains Mono', monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: #ece7da; color: var(--ink); font-family: var(--hand-body); }
+  body {
+    background-image:
+      radial-gradient(circle at 20% 30%, rgba(0,0,0,.025), transparent 40%),
+      radial-gradient(circle at 80% 70%, rgba(0,0,0,.02), transparent 40%);
+    min-height: 100vh;
+  }
+
+  /* Top page */
+  .page { max-width: 1320px; margin: 0 auto; padding: 28px 24px 80px; }
+  .page-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 14px; flex-wrap: wrap; }
+  .page-title { font-family: var(--hand-display); font-size: 48px; line-height: 1.08; margin: 0; letter-spacing: .005em; }
+  .page-sub { font-family: var(--hand-body); font-size: 15px; color: var(--ink-2); margin: 6px 0 0; max-width: 640px; }
+  .meta { font-family: var(--hand-mono); font-size: 11px; color: var(--ink-soft); text-transform: uppercase; letter-spacing: .12em; }
+
+  /* Tabs */
+  .tabs { display: flex; gap: 6px; margin: 18px 0 18px; flex-wrap: wrap; }
+  .tab {
+    font-family: var(--hand-display); font-size: 20px;
+    padding: 6px 16px 4px; border: 1.5px solid var(--rule);
+    background: var(--paper); color: var(--ink); cursor: pointer;
+    border-radius: 22px 26px 20px 24px / 24px 20px 26px 22px;
+    transform: rotate(-.3deg);
+    transition: transform .15s ease, background .15s;
+    line-height: 1.25; min-height: 34px; white-space: nowrap;
+  }
+  .tab:nth-child(2n) { transform: rotate(.4deg); border-radius: 24px 20px 26px 22px / 20px 26px 22px 24px; }
+  .tab:nth-child(3n) { transform: rotate(-.5deg); }
+  .tab:hover { background: #fff; }
+  .tab.on { background: var(--ink); color: var(--paper); }
+
+  /* Sketch frame (the device window) */
+  .sheet {
+    position: relative;
+    background: var(--paper);
+    border: 2px solid var(--rule);
+    border-radius: 18px 22px 16px 20px / 20px 18px 22px 16px;
+    box-shadow:
+      2px 3px 0 rgba(31,29,26,.08),
+      6px 8px 0 rgba(31,29,26,.04);
+    overflow: hidden;
+  }
+  .sheet::before {
+    /* faint paper texture */
+    content: ''; position: absolute; inset: 0; pointer-events: none;
+    background-image:
+      repeating-linear-gradient(0deg, rgba(0,0,0,.012) 0 1px, transparent 1px 28px);
+    mix-blend-mode: multiply;
+  }
+
+  /* App "window" chrome (light suggestion of OS) */
+  .winbar {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 8px 14px; border-bottom: 1.5px dashed var(--rule);
+    background: linear-gradient(180deg, #efeadd, #e7e1d2);
+    font-family: var(--hand-mono); font-size: 11px; color: var(--ink-soft);
+  }
+  .winbar .dots { display: flex; gap: 8px; }
+  .winbar .dots i { width: 10px; height: 10px; border-radius: 50%; border: 1.5px solid var(--rule); display: inline-block; }
+  .winbar .label { letter-spacing: .12em; text-transform: uppercase; }
+
+  .canvas { padding: 22px 26px 32px; padding-right: 240px; min-height: 720px; position: relative; }
+  @media (max-width: 1280px) { .canvas { padding-right: 26px; } }
+
+  /* Common sketchy primitives */
+  h2.h { font-family: var(--hand-display); font-size: 38px; margin: 0; }
+  h3.h { font-family: var(--hand-display); font-size: 26px; margin: 0; }
+  h4.h { font-family: var(--hand-display); font-size: 20px; margin: 0; letter-spacing: .01em; }
+  .lbl { font-family: var(--hand-mono); font-size: 11px; text-transform: uppercase; letter-spacing: .14em; color: var(--ink-soft); }
+  .lbl-tight { font-family: var(--hand-mono); font-size: 10.5px; letter-spacing: .14em; color: var(--ink-soft); text-transform: uppercase;}
+  .body { font-family: var(--hand-body); font-size: 14.5px; color: var(--ink-2); }
+
+  /* Sketchy borders */
+  .box {
+    border: 1.5px solid var(--rule);
+    border-radius: 14px 18px 12px 16px / 16px 12px 18px 14px;
+    background: rgba(255,255,255,.45);
+    padding: 16px 18px;
+    position: relative;
+  }
+  .box.hl { background: #fff7e8; border-style: solid; }
+  .box.dashed { border-style: dashed; }
+  .box.tight { padding: 12px 14px; }
+  .box.flat { background: transparent; }
+
+  .field {
+    display: flex; align-items: center; gap: 10px;
+    border: 1.5px solid var(--rule);
+    border-radius: 10px 14px 8px 12px / 12px 8px 14px 10px;
+    background: #fff;
+    padding: 8px 12px;
+    font-family: var(--hand-mono); font-size: 12.5px; color: var(--ink);
+    min-height: 38px;
+  }
+  .field.muted { background: #f5f1e6; color: var(--ink-2); }
+  .field .ph { color: var(--ink-soft); font-style: italic; }
+  .field .grow { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* Buttons (sketchy) */
+  .btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-family: var(--hand-display); font-size: 18px;
+    padding: 4px 14px 2px;
+    border: 1.5px solid var(--rule);
+    background: var(--paper);
+    color: var(--ink);
+    border-radius: 14px 18px 12px 16px / 16px 12px 18px 14px;
+    cursor: pointer;
+    line-height: 1.2;
+    transform: rotate(-.2deg);
+    box-shadow: 1px 2px 0 rgba(31,29,26,.08);
+    white-space: nowrap;
+  }
+  .btn:nth-of-type(2n) { transform: rotate(.3deg); }
+  .btn.primary { background: var(--accent); color: #fff; border-color: #6e3a14; }
+  .btn.ghost { background: transparent; }
+  .btn.sm { font-size: 15px; padding: 2px 10px 1px; }
+  .btn.lg { font-size: 22px; padding: 6px 18px 4px; }
+  .btn.icon { padding: 2px 9px 1px; font-family: var(--hand-mono); font-size: 13px; }
+
+  /* Pills/badges */
+  .pill {
+    font-family: var(--hand-mono); font-size: 10.5px;
+    padding: 2px 9px; border: 1.2px solid var(--rule);
+    border-radius: 999px;
+    text-transform: uppercase; letter-spacing: .1em;
+    background: var(--paper);
+  }
+  .pill.done { background: #e6f0dc; border-color: var(--good); color: var(--good); }
+  .pill.now  { background: var(--accent); color: #fff; border-color: #6e3a14; }
+  .pill.next { background: #fff; color: var(--ink-soft); border-style: dashed; }
+  .pill.warn { background: #fbe4d2; color: var(--bad); border-color: var(--bad); }
+  .pill.note { background: #e3ecf7; color: var(--note); border-color: var(--note); }
+
+  /* Stepper variants */
+  .stepper { display: flex; align-items: center; gap: 14px; }
+  .step-dot {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 30px; height: 30px; border: 1.5px solid var(--rule); border-radius: 50%;
+    font-family: var(--hand-display); font-size: 18px; background: var(--paper);
+  }
+  .step-dot.done { background: var(--good); color: #fff; border-color: var(--good); }
+  .step-dot.now  { background: var(--accent); color: #fff; border-color: #6e3a14; }
+  .step-dot.next { color: var(--ink-soft); }
+  .step-line { flex: 1; height: 0; border-top: 1.5px dashed var(--rule); }
+
+  /* Annotations (callouts that float beside artboards) */
+  .anno {
+    position: absolute;
+    font-family: var(--hand-display);
+    font-size: 16px;
+    color: var(--ink-2);
+    max-width: 200px;
+    line-height: 1.1;
+  }
+  @media (max-width: 1280px) { .anno { display: none; } }
+  .anno b { color: var(--ink); font-weight: 600; }
+  .anno .arrow {
+    display: block; font-family: var(--hand-mono); font-size: 12px; color: var(--ink-soft);
+  }
+
+  /* Direction header */
+  .dir-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    margin-bottom: 10px; gap: 14px; flex-wrap: wrap;
+  }
+  .dir-num {
+    font-family: var(--hand-display); font-size: 32px;
+    color: var(--ink); display: inline-block;
+    border-bottom: 2px solid var(--rule); padding: 0 4px 0 0; margin-right: 8px;
+  }
+  .dir-name { font-family: var(--hand-display); font-size: 34px; line-height: 1.15; color: var(--ink); margin-right: auto; }
+  .dir-tags { display: flex; gap: 6px; flex-wrap: wrap; }
+  .dir-desc { font-family: var(--hand-body); color: var(--ink-2); font-size: 15px; max-width: 760px; margin: 8px 0 14px; }
+
+  /* Layout helpers */
+  .row { display: flex; }
+  .col { display: flex; flex-direction: column; }
+  .gap-6 { gap: 6px; } .gap-8 { gap: 8px; } .gap-10 { gap: 10px; }
+  .gap-12 { gap: 12px; } .gap-16 { gap: 16px; } .gap-20 { gap: 20px; } .gap-24 { gap: 24px; }
+  .grow { flex: 1; min-width: 0; }
+  .between { justify-content: space-between; }
+  .center { align-items: center; }
+  .wrap { flex-wrap: wrap; }
+  .mt-4 { margin-top: 4px; } .mt-8 { margin-top: 8px; } .mt-12 { margin-top: 12px; } .mt-16 { margin-top: 16px; } .mt-20 { margin-top: 20px; }
+
+  /* Underline scribble */
+  .scribble {
+    background-image: linear-gradient(180deg, transparent 80%, rgba(196,106,42,.45) 80% 90%, transparent 90%);
+    padding: 0 2px;
+  }
+  .strike { text-decoration: line-through; text-decoration-color: var(--ink-soft); color: var(--ink-soft); }
+
+  /* Cards for plan items */
+  .plan-card {
+    border: 1.5px solid var(--rule); background: #fff;
+    border-radius: 12px 16px 10px 14px / 14px 10px 16px 12px;
+    padding: 12px 14px;
+    display: grid; grid-template-columns: 1fr auto; gap: 4px 14px;
+    align-items: center;
+  }
+  .plan-card .from { font-family: var(--hand-mono); font-size: 12px; color: var(--ink-soft); }
+  .plan-card .to { font-family: var(--hand-mono); font-size: 13.5px; color: var(--ink); }
+  .plan-card .arrow { font-family: var(--hand-mono); color: var(--ink-soft); }
+
+  /* Sidebar rail (used in some directions) */
+  .rail {
+    display: flex; flex-direction: column; gap: 14px;
+    padding: 18px 12px;
+    border-right: 1.5px dashed var(--rule);
+    min-width: 70px; align-items: center;
+  }
+  .rail .step-dot { width: 36px; height: 36px; font-size: 20px; }
+  .rail .rail-line { width: 0; flex: 1; min-height: 22px; border-left: 1.5px dashed var(--rule); }
+
+  /* Pseudo-input rows for plan-builder */
+  .kv {
+    display: grid; grid-template-columns: 110px 1fr auto; gap: 10px; align-items: center;
+    padding: 6px 0;
+  }
+  .kv .lbl { color: var(--ink-2); }
+
+  /* Theme blob top right */
+  .theme-blob {
+    display: inline-flex; align-items: center; gap: 6px;
+    border: 1.5px solid var(--rule);
+    border-radius: 10px 14px 8px 12px / 12px 8px 14px 10px;
+    padding: 4px 10px; background: var(--paper);
+    font-family: var(--hand-mono); font-size: 11px; color: var(--ink-soft);
+    text-transform: uppercase; letter-spacing: .12em;
+  }
+  .theme-blob .dot { width: 14px; height: 14px; border-radius: 50%; border: 1.5px solid var(--rule); }
+  .theme-blob .dot.sun { background: #ffe9b3; }
+  .theme-blob .dot.moon { background: #2a2724; }
+  .theme-blob .dot.auto { background: linear-gradient(135deg, #ffe9b3 50%, #2a2724 50%); }
+
+  /* Drop zone */
+  .drop {
+    border: 1.6px dashed var(--rule);
+    border-radius: 14px 18px 12px 16px / 16px 12px 18px 14px;
+    padding: 20px;
+    background: repeating-linear-gradient(45deg, transparent 0 8px, rgba(31,29,26,.025) 8px 9px);
+    text-align: center;
+  }
+
+  /* Note card */
+  .stat {
+    border: 1.4px solid var(--rule); border-radius: 12px;
+    padding: 8px 12px; min-width: 80px;
+    background: #fff;
+  }
+  .stat .num { font-family: var(--hand-display); font-size: 28px; line-height: 1; }
+  .stat .lbl { margin-top: 2px; }
+
+  /* Big number for dir number stamp */
+  .dir-stamp {
+    position: absolute; top: 14px; right: 18px;
+    font-family: var(--hand-display); font-size: 110px;
+    color: rgba(31,29,26,.05); line-height: .8; pointer-events: none;
+  }
+
+  /* Legend at top */
+  .legend {
+    display: flex; gap: 14px; flex-wrap: wrap; align-items: center;
+    font-family: var(--hand-body); font-size: 13px; color: var(--ink-2);
+  }
+  .legend .swatch { width: 14px; height: 14px; border: 1.5px solid var(--rule); display: inline-block; vertical-align: middle; margin-right: 4px; }
+  .legend .swatch.s1 { background: var(--accent); }
+  .legend .swatch.s2 { background: var(--good); }
+  .legend .swatch.s3 { background: #fff; }
+
+  /* When tweak: clean style (less sketchy) */
+  body.style-clean {
+    --hand-display: 'Inter', system-ui, sans-serif;
+    --hand-body: 'Inter', system-ui, sans-serif;
+    --rule: #232121;
+  }
+  body.style-clean .sheet,
+  body.style-clean .box,
+  body.style-clean .plan-card,
+  body.style-clean .field,
+  body.style-clean .btn,
+  body.style-clean .tab {
+    border-radius: 10px;
+    transform: none;
+  }
+  body.style-clean .btn { font-size: 13px; padding: 6px 12px; }
+  body.style-clean .btn.lg { font-size: 14px; padding: 8px 14px; }
+  body.style-clean h2.h { font-size: 24px; }
+  body.style-clean h3.h { font-size: 18px; }
+  body.style-clean h4.h { font-size: 15px; }
+
+  /* Compare grid */
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  @media (max-width: 1100px) { .grid-2 { grid-template-columns: 1fr; } }
+
+  /* Footer notes */
+  .footer-notes {
+    margin-top: 20px;
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
+    font-family: var(--hand-body); font-size: 14px; color: var(--ink-2);
+  }
+  @media (max-width: 900px) { .footer-notes { grid-template-columns: 1fr; } }
+  .footer-notes .note-card {
+    border: 1.5px dashed var(--rule); padding: 10px 12px;
+    background: rgba(255,255,255,.5);
+    border-radius: 10px 14px 8px 12px / 12px 8px 14px 10px;
+  }
+  .footer-notes .note-card b { font-family: var(--hand-display); font-size: 18px; color: var(--ink); }
+
+  /* Compare table for tone */
+  .copy-tbl {
+    border-collapse: separate; border-spacing: 0;
+    width: 100%;
+    font-family: var(--hand-body); font-size: 14px;
+  }
+  .copy-tbl th, .copy-tbl td {
+    text-align: left; padding: 6px 10px; border-bottom: 1px dashed rgba(0,0,0,.15);
+    vertical-align: top;
+  }
+  .copy-tbl th { font-family: var(--hand-mono); font-size: 11px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-soft); }
+  .copy-tbl .old { color: var(--ink-soft); text-decoration: line-through; }
+  .copy-tbl .new { color: var(--ink); }
+
+  /* Wireframe-y placeholder */
+  .ph-block {
+    background: repeating-linear-gradient(135deg, rgba(31,29,26,.05) 0 8px, transparent 8px 14px);
+    border: 1.4px dashed var(--rule);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-family: var(--hand-mono); font-size: 11px; color: var(--ink-soft);
+    text-transform: uppercase; letter-spacing: .1em;
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="tweaks-panel.jsx"></script>
+<script type="text/babel" src="wireframes.jsx"></script>
+</body>
+</html>

--- a/docs/specs/mockups/design-canvas.jsx
+++ b/docs/specs/mockups/design-canvas.jsx
@@ -1,0 +1,936 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), deletable, labels/titles are
+// inline-editable, and any artboard can be opened in a fullscreen focus
+// overlay (←/→/Esc). State persists to a .design-canvas.state.json sidecar
+// via the host bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    // isolation:isolate contains artboard content's z-indexes so a
+    // z-indexed child (sticky navbar etc.) can't paint over .dc-header or
+    // the .dc-menu popover that drops into the top of the card.
+    '.dc-card{isolation:isolate;transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    // Per-artboard header: grip + label on the left, delete/expand on the
+    // right. Single flex row; when the artboard's on-screen width is too
+    // narrow for both the label yields (ellipsis, then hidden entirely below
+    // ~4ch via the container query) and the buttons stay on the row.
+    '.dc-header{position:absolute;bottom:100%;left:-4px;margin-bottom:calc(4px * var(--dc-inv-zoom,1));z-index:2;',
+    '  display:flex;align-items:center;container-type:inline-size}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px;flex:1 1 auto;min-width:0}',
+    '.dc-grip{flex:0 0 auto;cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s,opacity .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{flex:1 1 auto;min-width:0;cursor:pointer;border-radius:4px;padding:3px 6px;',
+    '  display:flex;align-items:center;transition:background .12s;overflow:hidden}',
+    // Below ~4ch of label room: hide the label entirely, and drop the grip to
+    // hover-only (same reveal rule as .dc-btns) so a narrow header is clean
+    // until the card is moused.
+    '@container (max-width: 110px){',
+    '  .dc-labeltext{display:none}',
+    '  .dc-grip{opacity:0}',
+    '  [data-dc-slot]:hover .dc-grip{opacity:1}',
+    '}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-labeltext .dc-editable{overflow:hidden;text-overflow:ellipsis;max-width:100%}',
+    '.dc-labeltext .dc-editable:focus{overflow:visible;text-overflow:clip}',
+    '.dc-btns{flex:0 0 auto;margin-left:auto;display:flex;gap:2px;opacity:0;transition:opacity .12s}',
+    '[data-dc-slot]:hover .dc-btns,.dc-btns:has(.dc-menu){opacity:1}',
+    '.dc-expand,.dc-kebab{width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center;',
+    '  font:inherit;transition:background .12s,color .12s}',
+    '.dc-expand:hover,.dc-kebab:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    // Slot hosting an open menu floats above later siblings (which otherwise
+    // paint on top — same z-index:auto, later DOM order) so the popup isn't
+    // clipped by the next card.
+    '[data-dc-slot]:has(.dc-menu){z-index:10}',
+    '.dc-menu{position:absolute;top:100%;right:0;margin-top:4px;background:#fff;border-radius:8px;',
+    '  box-shadow:0 8px 28px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.05);padding:4px;min-width:160px;z-index:10}',
+    '.dc-menu button{display:block;width:100%;padding:7px 10px;border:0;background:transparent;',
+    '  border-radius:5px;font-family:inherit;font-size:13px;font-weight:500;line-height:1.2;',
+    '  color:#29261b;cursor:pointer;text-align:left;transition:background .12s;white-space:nowrap}',
+    '.dc-menu button:hover{background:rgba(0,0,0,.05)}',
+    '.dc-menu hr{border:0;border-top:1px solid rgba(0,0,0,.08);margin:4px 2px}',
+    '.dc-menu .dc-danger{color:#c96442}',
+    '.dc-menu .dc-danger:hover{background:rgba(201,100,66,.1)}',
+    // Chrome (titles / labels / buttons) counter-scales against the viewport
+    // zoom so it stays a constant on-screen size. --dc-inv-zoom is set by
+    // DCViewport on every transform update and inherits to all descendants —
+    // any overlay inside the world (e.g. a TweaksPanel on an artboard) can use
+    // it the same way.
+    //
+    // The header uses transform:scale (out-of-flow, so layout impact doesn't
+    // matter) with its world-space width set to card-width / inv-zoom so that
+    // after counter-scaling its on-screen width exactly matches the card's —
+    // that's what lets the container query + text-overflow behave against the
+    // card's visible edge at every zoom level.
+    //
+    // The section head uses CSS zoom instead of transform so its layout box
+    // grows with the counter-scale, pushing the card row down — otherwise the
+    // constant-screen-size title would overflow into the (shrinking) world-
+    // space gap and overlap the artboard headers at low zoom.
+    '.dc-header{width:calc((100% + 4px) / var(--dc-inv-zoom,1));',
+    '  transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom left}',
+    '.dc-sectionhead{zoom:var(--dc-inv-zoom,1)}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, hidden
+// artboards, focused artboard). Order/titles/labels/hidden persist to a
+// .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const abs = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (aid) abs.push([aid, ab]);
+    });
+    // hidden is scoped to one source revision — when the agent regenerates
+    // (artboard-ID set changes), prior deletes don't apply to new content.
+    const srcKey = abs.map(([k]) => k).join('\x1f');
+    const hidden = persisted.srcKey === srcKey ? (persisted.hidden || []) : [];
+    const srcIds = [];
+    abs.forEach(([aid, ab]) => {
+      if (hidden.includes(aid)) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+  // Persist viewport across reloads so the user lands back where they were
+  // after an agent edit or browser refresh. The sandbox origin is already
+  // per-project; pathname keeps multiple canvas files in one project apart.
+  const tfKey = 'dc-viewport:' + location.pathname;
+  const saveT = React.useRef(0);
+
+  const lastPostedScale = React.useRef();
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (!el) return;
+    el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+    // Exposed for zoom-invariant chrome (labels, buttons, TweaksPanel).
+    el.style.setProperty('--dc-inv-zoom', String(1 / scale));
+    // Keep the host toolbar's % readout in sync with the canvas scale. Pan
+    // ticks leave scale unchanged — skip the cross-frame post for those.
+    if (lastPostedScale.current !== scale) {
+      lastPostedScale.current = scale;
+      window.parent.postMessage({ type: '__dc_zoom', scale }, '*');
+    }
+    clearTimeout(saveT.current);
+    saveT.current = setTimeout(() => {
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    }, 200);
+  }, [tfKey]);
+
+  React.useLayoutEffect(() => {
+    const flush = () => {
+      clearTimeout(saveT.current);
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    };
+    try {
+      const s = JSON.parse(localStorage.getItem(tfKey) || 'null');
+      if (s && Number.isFinite(s.x) && Number.isFinite(s.y) && Number.isFinite(s.scale)) {
+        tf.current = { x: s.x, y: s.y, scale: Math.min(maxScale, Math.max(minScale, s.scale)) };
+        apply();
+      }
+    } catch {}
+    // Flush on pagehide and unmount so a reload within the 200ms debounce
+    // window doesn't drop the last pan/zoom.
+    window.addEventListener('pagehide', flush);
+    return () => { window.removeEventListener('pagehide', flush); flush(); };
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if ((e.ctrlKey || e.metaKey) && !isMouseWheel(e)) {
+        // trackpad pinch, or ctrl/cmd + smooth-scroll mouse. Notched
+        // wheels fall through to the fixed-step branch below.
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    // Host-driven zoom (toolbar % menu). Zooms around viewport centre so the
+    // visible midpoint stays fixed — matching the host's iframe-zoom feel.
+    const onHostMsg = (e) => {
+      const d = e.data;
+      if (d && d.type === '__dc_set_zoom' && typeof d.scale === 'number') {
+        const r = vp.getBoundingClientRect();
+        zoomAt(r.left + r.width / 2, r.top + r.height / 2, d.scale / tf.current.scale);
+      } else if (d && d.type === '__dc_probe') {
+        // Host's [readyGen] reset asks whether a canvas is present; it
+        // fires on the iframe's native 'load', which for canvases with
+        // images/fonts is after our mount-time announce, so re-announce.
+        // Clear the pan-tick guard so apply() re-posts the current scale
+        // even if it's unchanged — the host just reset dcScale to 1.
+        window.parent.postMessage({ type: '__dc_present' }, '*');
+        lastPostedScale.current = undefined;
+        apply();
+      }
+    };
+    window.addEventListener('message', onHostMsg);
+    // Announce canvas mode so the host toolbar proxies its % control here
+    // instead of scaling the iframe element (which would just shrink the
+    // viewport window of an infinite canvas). The apply() that follows emits
+    // the initial __dc_zoom so the toolbar % is correct before first pinch.
+    // lastPostedScale reset mirrors the __dc_probe handler: the layout
+    // effect's restore-path apply() may already have posted the restored
+    // scale (before __dc_present), so clear the guard to re-post it in order.
+    window.parent.postMessage({ type: '__dc_present' }, '*');
+    lastPostedScale.current = undefined;
+    apply();
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('message', onHostMsg);
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+  // Must match DesignCanvas's srcKey computation exactly (it filters falsy
+  // IDs), or onDelete persists a srcKey that DesignCanvas never recognizes.
+  const allIds = artboards.map((a) => a.props.id ?? a.props.label).filter(Boolean);
+  const srcKey = allIds.join('\x1f');
+  const hidden = sec.srcKey === srcKey ? (sec.hidden || []) : [];
+  const srcOrder = allIds.filter((k) => !hidden.includes(k));
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  // marginBottom counter-scales so the on-screen gap between sections stays
+  // constant — otherwise at low zoom the (world-space) gap collapses while
+  // the screen-constant sectionhead below it doesn't, and the title reads as
+  // belonging to the section above. paddingBottom below is just enough for
+  // the 24px artboard-header (abs-positioned above each card) plus ~8px, so
+  // the title sits tight against its own row at every zoom.
+  return (
+    <div data-dc-section={sid}
+      style={{ marginBottom: 'calc(80px * var(--dc-inv-zoom, 1))', position: 'relative' }}>
+      <div style={{ padding: '0 60px' }}>
+        <div className="dc-sectionhead" style={{ paddingBottom: 36 }}>
+          <DCEditable tag="div" value={sec.title ?? title}
+            onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+            style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+          {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onDelete={() => ctx && ctx.patchSection(sid, (x) => ({
+              hidden: [...(x.srcKey === srcKey ? (x.hidden || []) : []), k],
+              srcKey,
+            }))}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+// Per-artboard export (kind: 'png' | 'html'). Both paths share the same
+// self-contained clone: computed styles baked in, @font-face / <img> /
+// inline-style background-image urls inlined as data URIs. PNG wraps the
+// clone in foreignObject→canvas at 3× the artboard's natural width×height
+// (same pipeline the host uses for page captures); HTML wraps it in a
+// minimal standalone document. Both are independent of viewport zoom.
+async function dcExport(node, w, h, name, kind) {
+  try { await document.fonts.ready; } catch {}
+  const toDataURL = (url) => fetch(url).then((r) => r.blob()).then((b) => new Promise((res) => {
+    const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = () => res(url); fr.readAsDataURL(b);
+  })).catch(() => url);
+
+  // Collect @font-face rules. ss.cssRules throws SecurityError on
+  // cross-origin sheets (e.g. fonts.googleapis.com) — in that case fetch
+  // the CSS text directly (those endpoints send ACAO:*) and regex-extract
+  // the blocks. @import and @media/@supports are walked so nested
+  // @font-face rules aren't missed.
+  const fontRules = [], pending = [], seen = new Set();
+  const scrapeCss = (href) => {
+    if (seen.has(href)) return; seen.add(href);
+    pending.push(fetch(href).then((r) => r.text()).then((css) => {
+      for (const m of css.match(/@font-face\s*{[^}]*}/g) || []) fontRules.push({ css: m, base: href });
+      for (const m of css.matchAll(/@import\s+(?:url\()?['"]?([^'")\s;]+)/g))
+        scrapeCss(new URL(m[1], href).href);
+    }).catch(() => {}));
+  };
+  const walk = (rules, base) => {
+    for (const r of rules) {
+      if (r.type === CSSRule.FONT_FACE_RULE) fontRules.push({ css: r.cssText, base });
+      else if (r.type === CSSRule.IMPORT_RULE && r.styleSheet) {
+        const ibase = r.styleSheet.href || base;
+        try { walk(r.styleSheet.cssRules, ibase); } catch { scrapeCss(ibase); }
+      } else if (r.cssRules) walk(r.cssRules, base);
+    }
+  };
+  for (const ss of document.styleSheets) {
+    const base = ss.href || location.href;
+    try { walk(ss.cssRules, base); } catch { if (ss.href) scrapeCss(ss.href); }
+  }
+  while (pending.length) await pending.shift();
+  const fontCss = (await Promise.all(fontRules.map(async (rule) => {
+    let out = rule.css, m; const re = /url\((['"]?)([^'")]+)\1\)/g;
+    while ((m = re.exec(rule.css))) {
+      if (m[2].indexOf('data:') === 0) continue;
+      let abs; try { abs = new URL(m[2], rule.base).href; } catch { continue; }
+      out = out.split(m[0]).join('url("' + await toDataURL(abs) + '")');
+    }
+    return out;
+  }))).join('\n');
+
+  const cloneStyled = (src) => {
+    if (src.nodeType === 8 || (src.nodeType === 1 && src.tagName === 'SCRIPT')) return document.createTextNode('');
+    const dst = src.cloneNode(false);
+    if (src.nodeType === 1) {
+      const cs = getComputedStyle(src); let txt = '';
+      for (let i = 0; i < cs.length; i++) txt += cs[i] + ':' + cs.getPropertyValue(cs[i]) + ';';
+      dst.setAttribute('style', txt + 'animation:none;transition:none;');
+      if (src.tagName === 'CANVAS') try { const im = document.createElement('img'); im.src = src.toDataURL(); im.setAttribute('style', txt); return im; } catch {}
+    }
+    for (let c = src.firstChild; c; c = c.nextSibling) dst.appendChild(cloneStyled(c));
+    return dst;
+  };
+  const clone = cloneStyled(node);
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  // Drop the card's own shadow/radius so the export is a flush w×h rect;
+  // the artboard's own background (if any) is already in the computed style.
+  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0';
+
+  const jobs = [];
+  clone.querySelectorAll('img').forEach((el) => {
+    const s = el.getAttribute('src');
+    if (s && s.indexOf('data:') !== 0) jobs.push(toDataURL(el.src).then((d) => el.setAttribute('src', d)));
+  });
+  [clone, ...clone.querySelectorAll('*')].forEach((el) => {
+    const bg = el.style.backgroundImage; if (!bg) return;
+    let m; const re = /url\(["']?([^"')]+)["']?\)/g;
+    while ((m = re.exec(bg))) {
+      const tok = m[0], url = m[1];
+      if (url.indexOf('data:') === 0) continue;
+      jobs.push(toDataURL(url).then((d) => { el.style.backgroundImage = el.style.backgroundImage.split(tok).join('url("' + d + '")'); }));
+    }
+  });
+  await Promise.all(jobs);
+
+  const xml = new XMLSerializer().serializeToString(clone);
+  const save = (blob, ext) => {
+    if (!blob) return;
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = name + '.' + ext; a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  };
+
+  if (kind === 'html') {
+    const html = '<!doctype html><html><head><meta charset="utf-8"><title>' + name + '</title>' +
+      (fontCss ? '<style>' + fontCss + '</style>' : '') +
+      '</head><body style="margin:0">' + xml + '</body></html>';
+    return save(new Blob([html], { type: 'text/html' }), 'html');
+  }
+
+  // PNG: the SVG's own width/height must be the output resolution — an
+  // <img>-loaded SVG rasterizes at its intrinsic size, so sizing it at 1×
+  // and ctx.scale()-ing up would just upscale a 1× bitmap. viewBox maps the
+  // w×h foreignObject onto the px·w × px·h SVG canvas so the browser renders
+  // the HTML at full resolution.
+  const px = 3;
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w * px + '" height="' + h * px +
+    '" viewBox="0 0 ' + w + ' ' + h + '"><foreignObject width="' + w + '" height="' + h + '">' +
+    (fontCss ? '<style><![CDATA[' + fontCss + ']]></style>' : '') + xml + '</foreignObject></svg>';
+  const img = new Image();
+  await new Promise((res, rej) => {
+    img.onload = res; img.onerror = () => rej(new Error('svg load failed'));
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  });
+  const cv = document.createElement('canvas');
+  cv.width = w * px; cv.height = h * px;
+  cv.getContext('2d').drawImage(img, 0, 0);
+  cv.toBlob((blob) => save(blob, 'png'), 'image/png');
+}
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus, onDelete }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+  const cardRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  // ⋯ menu: close on any outside pointerdown. Two-click delete lives inside
+  // the menu — first click arms the row, second commits; closing disarms.
+  React.useEffect(() => {
+    if (!menuOpen) { setConfirming(false); return; }
+    const off = (e) => { if (!menuRef.current || !menuRef.current.contains(e.target)) setMenuOpen(false); };
+    document.addEventListener('pointerdown', off, true);
+    return () => document.removeEventListener('pointerdown', off, true);
+  }, [menuOpen]);
+
+  const doExport = (kind) => {
+    setMenuOpen(false);
+    if (!cardRef.current) return;
+    const name = String(label || id || 'artboard').replace(/[^\w\s.-]+/g, '_');
+    dcExport(cardRef.current, width, height, name, kind)
+      .catch((e) => console.error('[design-canvas] export failed:', e));
+  };
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-header" style={{ color: DC.label }} onPointerDown={(e) => e.stopPropagation()}>
+        <div className="dc-labelrow">
+          <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+            <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+          </div>
+          <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+            <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+              style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+          </div>
+        </div>
+        <div className="dc-btns">
+          <div ref={menuRef} style={{ position: 'relative' }}>
+            <button className="dc-kebab" title="More" onClick={() => setMenuOpen((o) => !o)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="2.5" cy="6" r="1.1"/><circle cx="6" cy="6" r="1.1"/><circle cx="9.5" cy="6" r="1.1"/></svg>
+            </button>
+            {menuOpen && (
+              <div className="dc-menu" onPointerDown={(e) => e.stopPropagation()}>
+                <button onClick={() => doExport('png')}>Download PNG</button>
+                <button onClick={() => doExport('html')}>Download HTML</button>
+                <hr />
+                <button className="dc-danger"
+                  onClick={() => { if (confirming) { setMenuOpen(false); onDelete(); } else setConfirming(true); }}>
+                  {confirming ? 'Click again to delete' : 'Delete'}
+                </button>
+              </div>
+            )}
+          </div>
+          <button className="dc-expand" onClick={onFocus} title="Focus">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+          </button>
+        </div>
+      </div>
+      <div ref={cardRef} className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    // Sections whose artboards are all deleted have slotIds:[] — step past
+    // them to the next non-empty section so ↑/↓ doesn't dead-end.
+    const n = sectionOrder.length;
+    for (let i = 1; i < n; i++) {
+      const ns = sectionOrder[(((secIdx + d * i) % n) + n) % n];
+      const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+      if (first) { ctx.setFocus(`${ns}/${first}`); return; }
+    }
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.filter((sid) => sectionMeta[sid].slotIds.length).map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/specs/mockups/hifi-mocks-v2.jsx
+++ b/docs/specs/mockups/hifi-mocks-v2.jsx
@@ -1,0 +1,336 @@
+/* global React, ReactDOM, DCSection, DCArtboard */
+const { useState } = React;
+
+// ─────────────────────────────────────────────
+// Step rail
+// ─────────────────────────────────────────────
+
+function VLabel({ text }) {
+  return (
+    <div className="rn-vlabel">
+      {text.split('').map((c, i) => <span key={i}>{c}</span>)}
+    </div>
+  );
+}
+
+function Rail({ active }) {
+  // active: 'plan' | 'review' | 'rename'
+  const order = ['plan', 'review', 'rename'];
+  const labels = { plan: 'PLAN', review: 'REVIEW', rename: 'RENAME' };
+  const numbers = { plan: 1, review: 2, rename: 3 };
+  const idx = order.indexOf(active);
+  return (
+    <div className="rn-rail">
+      {order.map((key, i) => {
+        const isNow = i === idx;
+        const isDone = i < idx;
+        const stateClass = isNow ? 'now' : isDone ? 'done' : 'next';
+        return (
+          <React.Fragment key={key}>
+            {i > 0 && <div className="rn-rail-line" />}
+            <div className={`rn-step is-${stateClass}`}>
+              <div className={`rn-dot ${stateClass}`}>
+                {isDone ? '✓' : numbers[key]}
+              </div>
+              <VLabel text={labels[key]} />
+            </div>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Window chrome
+// ─────────────────────────────────────────────
+
+function Window({ theme, children }) {
+  return (
+    <div className={`rn-window rn-${theme}`}>
+      <div className="rn-titlebar">
+        <div className="menu">
+          <span>File</span><span>View</span><span>Help</span>
+        </div>
+        <div>Renamer</div>
+        <div>— □ ✕</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Header({ title, sub }) {
+  return (
+    <div className="rn-header">
+      <div>
+        <h1 className="rn-title">{title}</h1>
+        {sub && <p className="rn-sub">{sub}</p>}
+      </div>
+      <div className="rn-theme-pill">
+        <span className="glyph" />
+        <span>Theme</span>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PLAN screen
+// ─────────────────────────────────────────────
+
+function PlanScreen({ theme, advanced }) {
+  return (
+    <Window theme={theme}>
+      <div className="rn-page">
+        <Header title="Renamer" sub="Plan · Review · Rename" />
+        <div className="rn-main">
+          <Rail active="plan" />
+          <div className="rn-workspace">
+            <div className="rn-ws-head">
+              <div className="crumbs">Step 1 of 3</div>
+              <h2>Pick a folder</h2>
+              <p>Choose the folder of photos you'd like to rename.</p>
+            </div>
+
+            <div className="rn-field-row">
+              <div className="rn-label">Photos</div>
+              <div className="rn-input">C:\Dev\Renamer\samples</div>
+              <div className="rn-icon-btn">📁</div>
+            </div>
+
+            <div className="rn-advanced">
+              <div className="rn-disc-row">
+                <div className="hint">Plan saved beside your photos as <code>rename-plan.json</code></div>
+                <button className="rn-disc-btn">{advanced ? 'Hide advanced ▴' : 'Advanced ▾'}</button>
+              </div>
+
+              {advanced && (
+                <div className="rn-advanced-body">
+                  <div className="rn-field-row">
+                    <div className="rn-label">Save folder</div>
+                    <div className="rn-input">C:\Dev\Renamer\samples</div>
+                    <div className="rn-icon-btn">📁</div>
+                  </div>
+                  <div className="rn-field-row">
+                    <div className="rn-label">Filename</div>
+                    <div className="rn-input">rename-plan.json</div>
+                    <div className="rn-icon-btn">✎</div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div style={{ flex: 1 }} />
+
+            <div className="rn-actions">
+              <span className="meta">2 subfolders found</span>
+              <div className="group">
+                <button className="rn-btn">Build plan</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Window>
+  );
+}
+
+// ─────────────────────────────────────────────
+// REVIEW screen
+// ─────────────────────────────────────────────
+
+const PLAN_ITEMS = [
+  { from: 'TestPhotos', to: '2017-11-08 — 2025-08-17 — TestPhotos', status: 'ok', label: 'ok · 2 photos' },
+  { from: 'Holiday-Crete', to: '2024-06-02 — 2024-06-14 — Holiday-Crete', status: 'ok', label: 'ok · 38 photos' },
+  { from: 'Birthday-2023', to: '2023-04-12 — 2023-04-12 — Birthday-2023', status: 'ok', label: 'ok · 14 photos' },
+  { from: 'Misc-Random', to: 'Misc-Random', status: 'warn', label: 'no dates' },
+];
+
+function ReviewScreen({ theme }) {
+  return (
+    <Window theme={theme}>
+      <div className="rn-page">
+        <Header title="Renamer" sub="Plan · Review · Rename" />
+        <div className="rn-main">
+          <Rail active="review" />
+          <div className="rn-workspace">
+            <div className="rn-ws-head">
+              <div className="crumbs">Step 2 of 3</div>
+              <h2>Review the plan</h2>
+              <p>Check the new names look right before anything is renamed.</p>
+            </div>
+
+            <div className="rn-stats">
+              <div className="rn-stat"><div className="num">3</div><div className="lbl">changes</div></div>
+              <div className="rn-stat"><div className="num">1</div><div className="lbl">notes</div></div>
+              <div className="rn-stat"><div className="num">54</div><div className="lbl">photos</div></div>
+            </div>
+
+            <div className="rn-cards">
+              {PLAN_ITEMS.map((it, i) => (
+                <div key={i} className={`rn-card ${it.status === 'warn' ? 'warn' : ''}`}>
+                  <div>
+                    <div className="from">{it.from}</div>
+                    <div className="to">{it.to}</div>
+                  </div>
+                  <span className={`rn-pill ${it.status}`}>{it.label}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="rn-actions">
+              <button className="rn-btn ghost sm">← Back to plan</button>
+              <div className="group">
+                <button className="rn-btn ghost sm">Reload plan</button>
+                <button className="rn-btn">Continue →</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Window>
+  );
+}
+
+// ─────────────────────────────────────────────
+// RENAME (apply finished) screen
+// ─────────────────────────────────────────────
+
+function RenameScreen({ theme }) {
+  return (
+    <Window theme={theme}>
+      <div className="rn-page">
+        <Header title="Renamer" sub="Plan · Review · Rename" />
+        <div className="rn-main">
+          <Rail active="rename" />
+          <div className="rn-workspace">
+            <div className="rn-ws-head">
+              <div className="crumbs">Step 3 of 3</div>
+              <h2>Rename folders</h2>
+              <p>This is the live rename. Review the plan before running it.</p>
+            </div>
+
+            <div className="rn-banner">
+              <div className="hl"><span className="check">✓</span> Renamed 3 folders</div>
+              <div className="breakdown">0 skipped · 0 failed · finished in 0.4s</div>
+              <button className="details-toggle">Details ▾</button>
+            </div>
+
+            <div className="rn-cards">
+              {PLAN_ITEMS.slice(0, 3).map((it, i) => (
+                <div key={i} className="rn-card">
+                  <div>
+                    <div className="from">{it.from}</div>
+                    <div className="to">{it.to}</div>
+                  </div>
+                  <span className="rn-pill ok">renamed</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="rn-actions">
+              <span className="meta">Report saved to logs folder</span>
+              <button className="rn-btn ghost sm">Open folder</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Window>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Token swatches artboard
+// ─────────────────────────────────────────────
+
+function Swatches({ theme }) {
+  const tokens = theme === 'light' ? [
+    ['BackgroundPrimary', '#F8FAFC'],
+    ['BackgroundSecondary', '#FFFFFF'],
+    ['BackgroundTertiary', '#F0F4F8'],
+    ['AccentMid (button)', '#D97706'],
+    ['AccentPrimary', '#854F0B'],
+    ['TextPrimary', '#1E293B'],
+    ['TextSecondary', '#475569'],
+    ['BorderPrimary', '#CBD5E1'],
+    ['StatusSuccess', '#166534'],
+    ['StatusError', '#9A3412'],
+    ['BadgeBackground', '#E2E8F0'],
+    ['TextLink', '#0F4C81'],
+  ] : [
+    ['BackgroundPrimary', '#0D1117'],
+    ['BackgroundSecondary', '#161B25'],
+    ['BackgroundTertiary', '#1E2535'],
+    ['AccentMid', '#EF9F27'],
+    ['AccentPrimary (button)', '#854F0B'],
+    ['TextPrimary', '#E8ECF4'],
+    ['TextSecondary', '#A8B4CC'],
+    ['BorderPrimary', '#2A3347'],
+    ['StatusSuccess', '#166534'],
+    ['StatusError', '#9A3412'],
+    ['BadgeBackground', '#1E2535'],
+    ['TextLink', '#FAC775'],
+  ];
+  return (
+    <div className="swatches" style={{ background: theme === 'dark' ? '#0D1117' : '#fff', color: theme === 'dark' ? '#E8ECF4' : '#111' }}>
+      {tokens.map(([name, hex]) => (
+        <div key={name} className="swatch" style={{ background: theme === 'dark' ? '#161B25' : '#fff', borderColor: theme === 'dark' ? '#2A3347' : '#e5e7eb' }}>
+          <div className="chip" style={{ background: hex }} />
+          <div className="meta">
+            <div className="name" style={{ color: theme === 'dark' ? '#E8ECF4' : '#111' }}>{name}</div>
+            <div className="hex">{hex}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// App
+// ─────────────────────────────────────────────
+
+function App() {
+  return (
+    <DesignCanvas title="Renamer · Hi-fi mocks (slice 340)">
+      <DCSection id="light" title="Light theme — full flow">
+        <DCArtboard id="plan-light" label="01 · Plan (defaults collapsed)" width={1100} height={720}>
+          <PlanScreen theme="light" advanced={false} />
+        </DCArtboard>
+        <DCArtboard id="plan-light-adv" label="01b · Plan (Advanced expanded)" width={1100} height={720}>
+          <PlanScreen theme="light" advanced={true} />
+        </DCArtboard>
+        <DCArtboard id="review-light" label="02 · Review" width={1100} height={720}>
+          <ReviewScreen theme="light" />
+        </DCArtboard>
+        <DCArtboard id="rename-light" label="03 · Rename (finished)" width={1100} height={720}>
+          <RenameScreen theme="light" />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="dark" title="Dark theme — full flow">
+        <DCArtboard id="plan-dark" label="01 · Plan" width={1100} height={720}>
+          <PlanScreen theme="dark" advanced={false} />
+        </DCArtboard>
+        <DCArtboard id="review-dark" label="02 · Review" width={1100} height={720}>
+          <ReviewScreen theme="dark" />
+        </DCArtboard>
+        <DCArtboard id="rename-dark" label="03 · Rename" width={1100} height={720}>
+          <RenameScreen theme="dark" />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="tokens" title="Theme tokens (mirrored from LightTheme.xaml / DarkTheme.xaml)">
+        <DCArtboard id="tokens-light" label="Light tokens" width={760} height={520}>
+          <Swatches theme="light" />
+        </DCArtboard>
+        <DCArtboard id="tokens-dark" label="Dark tokens" width={760} height={520}>
+          <Swatches theme="dark" />
+        </DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/docs/specs/mockups/hifi-mocks.jsx
+++ b/docs/specs/mockups/hifi-mocks.jsx
@@ -1,0 +1,336 @@
+/* global React, ReactDOM, DCSection, DCArtboard */
+const { useState } = React;
+
+// ─────────────────────────────────────────────
+// Step rail
+// ─────────────────────────────────────────────
+
+function VLabel({ text }) {
+  return (
+    <div className="rn-vlabel">
+      {text.split('').map((c, i) => <span key={i}>{c}</span>)}
+    </div>
+  );
+}
+
+function Rail({ active }) {
+  // active: 'plan' | 'review' | 'rename'
+  const order = ['plan', 'review', 'rename'];
+  const labels = { plan: 'PLAN', review: 'REVIEW', rename: 'RENAME' };
+  const numbers = { plan: 1, review: 2, rename: 3 };
+  const idx = order.indexOf(active);
+  return (
+    <div className="rn-rail">
+      {order.map((key, i) => {
+        const isNow = i === idx;
+        const isDone = i < idx;
+        const stateClass = isNow ? 'now' : isDone ? 'done' : 'next';
+        return (
+          <React.Fragment key={key}>
+            {i > 0 && <div className="rn-rail-line" />}
+            <div className={`rn-step is-${stateClass}`}>
+              <div className={`rn-dot ${stateClass}`}>
+                {isDone ? '✓' : numbers[key]}
+              </div>
+              <VLabel text={labels[key]} />
+            </div>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Window chrome
+// ─────────────────────────────────────────────
+
+function Window({ theme, children }) {
+  return (
+    <div className={`rn-window rn-${theme}`}>
+      <div className="rn-titlebar">
+        <div className="menu">
+          <span>File</span><span>View</span><span>Help</span>
+        </div>
+        <div>Renamer</div>
+        <div>— □ ✕</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Header({ title, sub }) {
+  return (
+    <div className="rn-header">
+      <div>
+        <h1 className="rn-title">{title}</h1>
+        {sub && <p className="rn-sub">{sub}</p>}
+      </div>
+      <div className="rn-theme-pill">
+        <span className="glyph" />
+        <span>Theme</span>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PLAN screen
+// ─────────────────────────────────────────────
+
+function PlanScreen({ theme, advanced }) {
+  return (
+    <Window theme={theme}>
+      <div className="rn-page">
+        <Header title="Renamer" sub="Plan · Review · Rename" />
+        <div className="rn-main">
+          <Rail active="plan" />
+          <div className="rn-workspace">
+            <div className="rn-ws-head">
+              <div className="crumbs">Step 1 of 3</div>
+              <h2>Pick a folder</h2>
+              <p>Choose the folder of photos you'd like to rename.</p>
+            </div>
+
+            <div className="rn-field-row">
+              <div className="rn-label">Photos</div>
+              <div className="rn-input">C:\Dev\Renamer\samples</div>
+              <div className="rn-icon-btn">📁</div>
+            </div>
+
+            <div className="rn-advanced">
+              <div className="rn-disc-row">
+                <div className="hint">Plan saved beside your photos as <code>rename-plan.json</code></div>
+                <button className="rn-disc-btn">{advanced ? 'Hide advanced ▴' : 'Advanced ▾'}</button>
+              </div>
+
+              {advanced && (
+                <div className="rn-advanced-body">
+                  <div className="rn-field-row">
+                    <div className="rn-label">Save folder</div>
+                    <div className="rn-input">C:\Dev\Renamer\samples</div>
+                    <div className="rn-icon-btn">📁</div>
+                  </div>
+                  <div className="rn-field-row">
+                    <div className="rn-label">Filename</div>
+                    <div className="rn-input">rename-plan.json</div>
+                    <div className="rn-icon-btn">✎</div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div style={{ flex: 1 }} />
+
+            <div className="rn-actions">
+              <span className="meta">2 subfolders found</span>
+              <div className="group">
+                <button className="rn-btn">Build plan</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Window>
+  );
+}
+
+// ─────────────────────────────────────────────
+// REVIEW screen
+// ─────────────────────────────────────────────
+
+const PLAN_ITEMS = [
+  { from: 'TestPhotos', to: '2017-11-08 — 2025-08-17 — TestPhotos', status: 'ok', label: 'ok · 2 photos' },
+  { from: 'Holiday-Crete', to: '2024-06-02 — 2024-06-14 — Holiday-Crete', status: 'ok', label: 'ok · 38 photos' },
+  { from: 'Birthday-2023', to: '2023-04-12 — 2023-04-12 — Birthday-2023', status: 'ok', label: 'ok · 14 photos' },
+  { from: 'Misc-Random', to: 'Misc-Random', status: 'warn', label: 'no dates' },
+];
+
+function ReviewScreen({ theme }) {
+  return (
+    <Window theme={theme}>
+      <div className="rn-page">
+        <Header title="Renamer" sub="Plan · Review · Rename" />
+        <div className="rn-main">
+          <Rail active="review" />
+          <div className="rn-workspace">
+            <div className="rn-ws-head">
+              <div className="crumbs">Step 2 of 3</div>
+              <h2>Review the plan</h2>
+              <p>Check the new names look right before anything is renamed.</p>
+            </div>
+
+            <div className="rn-stats">
+              <div className="rn-stat"><div className="num">3</div><div className="lbl">changes</div></div>
+              <div className="rn-stat"><div className="num">1</div><div className="lbl">notes</div></div>
+              <div className="rn-stat"><div className="num">54</div><div className="lbl">photos</div></div>
+            </div>
+
+            <div className="rn-cards">
+              {PLAN_ITEMS.map((it, i) => (
+                <div key={i} className={`rn-card ${it.status === 'warn' ? 'warn' : ''}`}>
+                  <div>
+                    <div className="from">{it.from}</div>
+                    <div className="to">{it.to}</div>
+                  </div>
+                  <span className={`rn-pill ${it.status}`}>{it.label}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="rn-actions">
+              <button className="rn-btn ghost sm">← Back to plan</button>
+              <div className="group">
+                <button className="rn-btn ghost sm">Reload plan</button>
+                <button className="rn-btn">Continue →</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Window>
+  );
+}
+
+// ─────────────────────────────────────────────
+// RENAME (apply finished) screen
+// ─────────────────────────────────────────────
+
+function RenameScreen({ theme }) {
+  return (
+    <Window theme={theme}>
+      <div className="rn-page">
+        <Header title="Renamer" sub="Plan · Review · Rename" />
+        <div className="rn-main">
+          <Rail active="rename" />
+          <div className="rn-workspace">
+            <div className="rn-ws-head">
+              <div className="crumbs">Step 3 of 3</div>
+              <h2>Rename folders</h2>
+              <p>This is the live rename. Review the plan before running it.</p>
+            </div>
+
+            <div className="rn-banner">
+              <div className="hl"><span className="check">✓</span> Renamed 3 folders</div>
+              <div className="breakdown">0 skipped · 0 failed · finished in 0.4s</div>
+              <button className="details-toggle">Details ▾</button>
+            </div>
+
+            <div className="rn-cards">
+              {PLAN_ITEMS.slice(0, 3).map((it, i) => (
+                <div key={i} className="rn-card">
+                  <div>
+                    <div className="from">{it.from}</div>
+                    <div className="to">{it.to}</div>
+                  </div>
+                  <span className="rn-pill ok">renamed</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="rn-actions">
+              <span className="meta">Report saved to logs folder</span>
+              <button className="rn-btn ghost sm">Open folder</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Window>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Token swatches artboard
+// ─────────────────────────────────────────────
+
+function Swatches({ theme }) {
+  const tokens = theme === 'light' ? [
+    ['BackgroundPrimary', '#F8FAFC'],
+    ['BackgroundSecondary', '#FFFFFF'],
+    ['BackgroundTertiary', '#F0F4F8'],
+    ['AccentMid (button)', '#D97706'],
+    ['AccentPrimary', '#854F0B'],
+    ['TextPrimary', '#1E293B'],
+    ['TextSecondary', '#475569'],
+    ['BorderPrimary', '#CBD5E1'],
+    ['StatusSuccess', '#166534'],
+    ['StatusError', '#9A3412'],
+    ['BadgeBackground', '#E2E8F0'],
+    ['TextLink', '#0F4C81'],
+  ] : [
+    ['BackgroundPrimary', '#0D1117'],
+    ['BackgroundSecondary', '#161B25'],
+    ['BackgroundTertiary', '#1E2535'],
+    ['AccentMid', '#EF9F27'],
+    ['AccentPrimary (button)', '#854F0B'],
+    ['TextPrimary', '#E8ECF4'],
+    ['TextSecondary', '#A8B4CC'],
+    ['BorderPrimary', '#2A3347'],
+    ['StatusSuccess', '#166534'],
+    ['StatusError', '#9A3412'],
+    ['BadgeBackground', '#1E2535'],
+    ['TextLink', '#FAC775'],
+  ];
+  return (
+    <div className="swatches" style={{ background: theme === 'dark' ? '#0D1117' : '#fff', color: theme === 'dark' ? '#E8ECF4' : '#111' }}>
+      {tokens.map(([name, hex]) => (
+        <div key={name} className="swatch" style={{ background: theme === 'dark' ? '#161B25' : '#fff', borderColor: theme === 'dark' ? '#2A3347' : '#e5e7eb' }}>
+          <div className="chip" style={{ background: hex }} />
+          <div className="meta">
+            <div className="name" style={{ color: theme === 'dark' ? '#E8ECF4' : '#111' }}>{name}</div>
+            <div className="hex">{hex}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// App
+// ─────────────────────────────────────────────
+
+function App() {
+  return (
+    <DesignCanvas title="Renamer · Hi-fi mocks (slice 340)">
+      <DCSection id="light" title="Light theme — full flow">
+        <DCArtboard id="plan-light" label="01 · Plan (defaults collapsed)" width={1100} height={720}>
+          <PlanScreen theme="light" advanced={false} />
+        </DCArtboard>
+        <DCArtboard id="plan-light-adv" label="01b · Plan (Advanced expanded)" width={1100} height={720}>
+          <PlanScreen theme="light" advanced={true} />
+        </DCArtboard>
+        <DCArtboard id="review-light" label="02 · Review" width={1100} height={720}>
+          <ReviewScreen theme="light" />
+        </DCArtboard>
+        <DCArtboard id="rename-light" label="03 · Rename (finished)" width={1100} height={720}>
+          <RenameScreen theme="light" />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="dark" title="Dark theme — full flow">
+        <DCArtboard id="plan-dark" label="01 · Plan" width={1100} height={720}>
+          <PlanScreen theme="dark" advanced={false} />
+        </DCArtboard>
+        <DCArtboard id="review-dark" label="02 · Review" width={1100} height={720}>
+          <ReviewScreen theme="dark" />
+        </DCArtboard>
+        <DCArtboard id="rename-dark" label="03 · Rename" width={1100} height={720}>
+          <RenameScreen theme="dark" />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="tokens" title="Theme tokens (mirrored from LightTheme.xaml / DarkTheme.xaml)">
+        <DCArtboard id="tokens-light" label="Light tokens" width={760} height={520}>
+          <Swatches theme="light" />
+        </DCArtboard>
+        <DCArtboard id="tokens-dark" label="Dark tokens" width={760} height={520}>
+          <Swatches theme="dark" />
+        </DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/docs/specs/mockups/tweaks-panel.jsx
+++ b/docs/specs/mockups/tweaks-panel.jsx
@@ -1,0 +1,568 @@
+
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "palette": ["#D97757", "#29261b", "#f6f4ef"],
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        options={['#D97757', '#2A6FDB', '#1F8A5B', '#7A5AE0']}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakColor  label="Palette" value={t.palette}
+//                        options={[['#D97757', '#29261b', '#f6f4ef'],
+//                                  ['#475569', '#0f172a', '#f1f5f9']]}
+//                        onChange={(v) => setTweak('palette', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom right;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;width:100%;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+
+  .twk-chips{display:flex;gap:6px}
+  .twk-chip{position:relative;appearance:none;flex:1;min-width:0;height:46px;
+    padding:0;border:0;border-radius:6px;overflow:hidden;cursor:default;
+    box-shadow:0 0 0 .5px rgba(0,0,0,.12),0 1px 2px rgba(0,0,0,.06);
+    transition:transform .12s cubic-bezier(.3,.7,.4,1),box-shadow .12s}
+  .twk-chip:hover{transform:translateY(-1px);
+    box-shadow:0 0 0 .5px rgba(0,0,0,.18),0 4px 10px rgba(0,0,0,.12)}
+  .twk-chip[data-on="1"]{box-shadow:0 0 0 1.5px rgba(0,0,0,.85),
+    0 2px 6px rgba(0,0,0,.15)}
+  .twk-chip>span{position:absolute;top:0;bottom:0;right:0;width:34%;
+    display:flex;flex-direction:column;box-shadow:-1px 0 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i{flex:1;box-shadow:0 -1px 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i:first-child{box-shadow:none}
+  .twk-chip svg{position:absolute;top:6px;left:6px;width:13px;height:13px;
+    filter:drop-shadow(0 1px 1px rgba(0,0,0,.3))}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+    // Same-window signal so in-page listeners (deck-stage rail thumbnails)
+    // can react — the parent message only reaches the host, not peers.
+    window.dispatchEvent(new CustomEvent('tweakchange', { detail: edits }));
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', noDeckControls = false, children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  // Auto-inject a rail toggle when a <deck-stage> is on the page. The
+  // toggle drives the deck's per-viewer _railVisible via window message;
+  // state is mirrored from the same localStorage key the deck reads so
+  // the control reflects reality across reloads. The mechanism is the
+  // message — authors who want custom placement can post it directly
+  // and pass noDeckControls to suppress this one.
+  const hasDeckStage = React.useMemo(
+    () => typeof document !== 'undefined' && !!document.querySelector('deck-stage'),
+    [],
+  );
+  // Hide the toggle until the host has actually enabled the rail (the
+  // __omelette_rail_enabled window message, posted only when the
+  // omelette_deck_rail_enabled flag is on for this user). The initial read
+  // covers TweaksPanel mounting after the message already arrived; the
+  // listener covers the common case of mounting first.
+  const [railEnabled, setRailEnabled] = React.useState(
+    () => hasDeckStage && !!document.querySelector('deck-stage')?._railEnabled,
+  );
+  React.useEffect(() => {
+    if (!hasDeckStage || railEnabled) return undefined;
+    const onMsg = (e) => {
+      if (e.data && e.data.type === '__omelette_rail_enabled') setRailEnabled(true);
+    };
+    window.addEventListener('message', onMsg);
+    return () => window.removeEventListener('message', onMsg);
+  }, [hasDeckStage, railEnabled]);
+  const [railVisible, setRailVisible] = React.useState(() => {
+    try { return localStorage.getItem('deck-stage.railVisible') !== '0'; } catch (e) { return true; }
+  });
+  const toggleRail = (on) => {
+    setRailVisible(on);
+    window.postMessage({ type: '__deck_rail_visible', on }, '*');
+  };
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel" data-noncommentable=""
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">
+          {children}
+          {hasDeckStage && railEnabled && !noDeckControls && (
+            <TweakSection label="Deck">
+              <TweakToggle label="Thumbnail rail" value={railVisible} onChange={toggleRail} />
+            </TweakSection>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  // Segments wrap mid-word once per-segment width runs out. The track is
+  // ~248px (280 panel − 28 body pad − 4 seg pad), each button loses 12px
+  // to its own padding, and 11.5px system-ui averages ~6.3px/char — so 2
+  // options fit ~16 chars each, 3 fit ~10. Past that (or >3 options), fall
+  // back to a dropdown rather than wrap.
+  const labelLen = (o) => String(typeof o === 'object' ? o.label : o).length;
+  const maxLen = options.reduce((m, o) => Math.max(m, labelLen(o)), 0);
+  const fitsAsSegments = maxLen <= ({ 2: 16, 3: 10 }[options.length] ?? 0);
+  if (!fitsAsSegments) {
+    // <select> emits strings — map back to the original option value so the
+    // fallback stays type-preserving (numbers, booleans) like the segment path.
+    const resolve = (s) => {
+      const m = options.find((o) => String(typeof o === 'object' ? o.value : o) === s);
+      return m === undefined ? s : typeof m === 'object' ? m.value : m;
+    };
+    return <TweakSelect label={label} value={value} options={options}
+                        onChange={(s) => onChange(resolve(s))} />;
+  }
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+// Relative-luminance contrast pick — checkmarks drawn over a swatch need to
+// read on both #111 and #fafafa without per-option configuration. Hex input
+// only (#rgb / #rrggbb); named or rgb()/hsl() colors fall through to "light".
+function __twkIsLight(hex) {
+  const h = String(hex).replace('#', '');
+  const x = h.length === 3 ? h.replace(/./g, (c) => c + c) : h.padEnd(6, '0');
+  const n = parseInt(x.slice(0, 6), 16);
+  if (Number.isNaN(n)) return true;
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  return r * 299 + g * 587 + b * 114 > 148000;
+}
+
+const __TwkCheck = ({ light }) => (
+  <svg viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M3 7.2 5.8 10 11 4.2" fill="none" strokeWidth="2.2"
+          strokeLinecap="round" strokeLinejoin="round"
+          stroke={light ? 'rgba(0,0,0,.78)' : '#fff'} />
+  </svg>
+);
+
+// TweakColor — curated color/palette picker. Each option is either a single
+// hex string or an array of 1-5 hex strings; the card adapts — a lone color
+// renders solid, a palette renders colors[0] as the hero (left ~2/3) with the
+// rest stacked in a sharp column on the right. onChange emits the
+// option in the shape it was passed (string stays string, array stays array).
+// Without options it falls back to the native color input for back-compat.
+function TweakColor({ label, value, options, onChange }) {
+  if (!options || !options.length) {
+    return (
+      <div className="twk-row twk-row-h">
+        <div className="twk-lbl"><span>{label}</span></div>
+        <input type="color" className="twk-swatch" value={value}
+               onChange={(e) => onChange(e.target.value)} />
+      </div>
+    );
+  }
+  // Native <input type=color> emits lowercase hex per the HTML spec, so
+  // compare case-insensitively. String() guards JSON.stringify(undefined),
+  // which returns the primitive undefined (no .toLowerCase).
+  const key = (o) => String(JSON.stringify(o)).toLowerCase();
+  const cur = key(value);
+  return (
+    <TweakRow label={label}>
+      <div className="twk-chips" role="radiogroup">
+        {options.map((o, i) => {
+          const colors = Array.isArray(o) ? o : [o];
+          const [hero, ...rest] = colors;
+          const sup = rest.slice(0, 4);
+          const on = key(o) === cur;
+          return (
+            <button key={i} type="button" className="twk-chip" role="radio"
+                    aria-checked={on} data-on={on ? '1' : '0'}
+                    aria-label={colors.join(', ')} title={colors.join(' · ')}
+                    style={{ background: hero }}
+                    onClick={() => onChange(o)}>
+              {sup.length > 0 && (
+                <span>
+                  {sup.map((c, j) => <i key={j} style={{ background: c }} />)}
+                </span>
+              )}
+              {on && <__TwkCheck light={__twkIsLight(hero)} />}
+            </button>
+          );
+        })}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});

--- a/docs/specs/mockups/wireframes.jsx
+++ b/docs/specs/mockups/wireframes.jsx
@@ -1,0 +1,694 @@
+/* global React, ReactDOM */
+const { useState } = React;
+
+// ────────────────────────────────────────────────
+// Shared bits
+// ────────────────────────────────────────────────
+
+function WinBar({ title }) {
+  return (
+    <div className="winbar">
+      <div className="dots"><i/><i/><i/></div>
+      <div className="label">Renamer · {title}</div>
+      <div style={{ fontFamily: 'var(--hand-mono)', fontSize: 11 }}>— □ ✕</div>
+    </div>
+  );
+}
+
+function ThemeBlob() {
+  return (
+    <div className="theme-blob">
+      <span className="dot sun" /> <span className="dot moon" /> <span className="dot auto" />
+      <span style={{ marginLeft: 4 }}>theme</span>
+    </div>
+  );
+}
+
+function StepDot({ n, state }) {
+  return <span className={`step-dot ${state}`}>{state === 'done' ? '✓' : n}</span>;
+}
+
+function Anno({ children, style }) {
+  return <div className="anno" style={style}>{children}</div>;
+}
+
+const SAMPLE_FOLDER = 'C:\\Dev\\Renamer\\samples';
+
+// ────────────────────────────────────────────────
+// Direction A — One page, no sidebar, smart defaults
+// ────────────────────────────────────────────────
+
+function DirectionA() {
+  return (
+    <div className="sheet">
+      <WinBar title="Direction A · single scrolling page" />
+      <div className="canvas">
+        <div className="dir-stamp">A</div>
+
+        {/* compact header */}
+        <div className="row between center wrap gap-12">
+          <div className="col gap-6">
+            <h2 className="h">Renamer</h2>
+            <div className="body">Rename a folder of photos by date in three quick steps.</div>
+          </div>
+          <ThemeBlob />
+        </div>
+
+        {/* top stepper replaces left sidebar */}
+        <div className="stepper mt-16" style={{ maxWidth: 720 }}>
+          <StepDot n={1} state="now" />
+          <span className="lbl">Plan</span>
+          <span className="step-line" />
+          <StepDot n={2} state="next" />
+          <span className="lbl">Review</span>
+          <span className="step-line" />
+          <StepDot n={3} state="next" />
+          <span className="lbl">Rename</span>
+        </div>
+
+        {/* main card */}
+        <div className="box mt-16" style={{ padding: 18 }}>
+          <div className="row between center">
+            <h3 className="h">1. Pick your photo folder</h3>
+            <span className="pill">step 1 of 3</span>
+          </div>
+
+          <div className="kv mt-12">
+            <span className="lbl">Photos</span>
+            <div className="field">
+              <span className="grow">{SAMPLE_FOLDER}</span>
+            </div>
+            <button className="btn sm">Browse…</button>
+          </div>
+
+          {/* defaults panel */}
+          <div className="box dashed flat mt-12" style={{ padding: 12 }}>
+            <div className="row between center">
+              <span className="lbl">Plan saved alongside your photos</span>
+              <button className="btn sm ghost">Change… ▾</button>
+            </div>
+            <div className="body mt-4" style={{ color: 'var(--ink-soft)' }}>
+              <span style={{ fontFamily: 'var(--hand-mono)', fontSize: 12 }}>
+                {SAMPLE_FOLDER}\<b>rename-plan.json</b>
+              </span>
+            </div>
+          </div>
+
+          <div className="row mt-16 gap-10 center">
+            <button className="btn primary lg">Build plan →</button>
+            <span className="body" style={{ color: 'var(--ink-soft)' }}>
+              We'll scan the folder and propose new names.
+            </span>
+          </div>
+        </div>
+
+        <Anno style={{ top: 30, right: 18, width: 200 }}>
+          <b>Title shrinks.</b><br/>
+          Steps live in a stepper.
+          <span className="arrow">↙</span>
+        </Anno>
+
+        <Anno style={{ top: 240, right: 18, width: 200 }}>
+          Defaults baked in:<br/>
+          <b>save = photo folder</b>,<br/>
+          <b>filename = rename-plan.json</b>.<br/>
+          Revealed only if needed.
+          <span className="arrow">↙</span>
+        </Anno>
+
+        <Anno style={{ top: 470, right: 18, width: 200 }}>
+          One <b>Build plan</b> button.<br/>
+          No full-width orange.
+          <span className="arrow">↙</span>
+        </Anno>
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Direction B — Wizard with thin numbered rail
+// ────────────────────────────────────────────────
+
+function DirectionB() {
+  return (
+    <div className="sheet">
+      <WinBar title="Direction B · wizard with rail" />
+      <div className="canvas" style={{ padding: 0 }}>
+        <div className="dir-stamp">B</div>
+
+        <div className="row" style={{ minHeight: 720 }}>
+          {/* Thin rail */}
+          <div className="rail">
+            <StepDot n={1} state="done" />
+            <span className="lbl-tight" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>plan</span>
+            <span className="rail-line" />
+            <StepDot n={2} state="now" />
+            <span className="lbl-tight" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>review</span>
+            <span className="rail-line" />
+            <StepDot n={3} state="next" />
+            <span className="lbl-tight" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>rename</span>
+          </div>
+
+          {/* main */}
+          <div className="grow col gap-16" style={{ padding: '22px 26px 32px' }}>
+            <div className="row between center wrap">
+              <div>
+                <div className="lbl">Step 2 of 3</div>
+                <h2 className="h">Review the plan</h2>
+                <div className="body">2 folder changes proposed · 0 problems</div>
+              </div>
+              <ThemeBlob />
+            </div>
+
+            {/* summary strip */}
+            <div className="row gap-10 wrap">
+              <div className="stat"><div className="num">2</div><div className="lbl">changes</div></div>
+              <div className="stat"><div className="num">0</div><div className="lbl">notes</div></div>
+              <div className="stat" style={{ background: '#f5f1e6' }}>
+                <div className="lbl">from</div>
+                <div className="body" style={{ fontFamily: 'var(--hand-mono)', fontSize: 12 }}>{SAMPLE_FOLDER}</div>
+              </div>
+            </div>
+
+            {/* plan cards */}
+            <div className="col gap-8">
+              <h4 className="h">Proposed names</h4>
+              <div className="plan-card">
+                <div className="col">
+                  <span className="from">TestPhotos</span>
+                  <span className="to"><b>2017-11-08 — 2025-08-17 — TestPhotos</b></span>
+                </div>
+                <span className="pill note">2 photos · ok</span>
+              </div>
+              <div className="plan-card">
+                <div className="col">
+                  <span className="from">Holiday-Crete</span>
+                  <span className="to"><b>2024-06-02 — 2024-06-14 — Holiday-Crete</b></span>
+                </div>
+                <span className="pill note">38 photos · ok</span>
+              </div>
+            </div>
+
+            {/* footer actions */}
+            <div className="row between center mt-12 wrap gap-10">
+              <button className="btn ghost sm">← Back to plan</button>
+              <div className="row gap-10">
+                <button className="btn">Reload plan</button>
+                <button className="btn primary lg">Continue →</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <Anno style={{ top: 60, right: 18, width: 200 }}>
+          Sidebar collapses to a<br/>
+          <b>thin numbered rail</b>.
+          <span className="arrow">↙</span>
+        </Anno>
+        <Anno style={{ top: 240, right: 18, width: 200 }}>
+          Stat strip replaces the<br/>
+          three "Before you rename"<br/>
+          cards.
+          <span className="arrow">↙</span>
+        </Anno>
+        <Anno style={{ top: 460, right: 18, width: 200 }}>
+          Each folder = one<br/>
+          <b>plan card</b> with a<br/>
+          status pill.
+          <span className="arrow">↙</span>
+        </Anno>
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Direction C — Compact, two-column with inline buttons
+// ────────────────────────────────────────────────
+
+function DirectionC() {
+  return (
+    <div className="sheet">
+      <WinBar title="Direction C · compact two-column" />
+      <div className="canvas">
+        <div className="dir-stamp">C</div>
+
+        <div className="row between center wrap gap-12">
+          <div className="col">
+            <h3 className="h">Renamer</h3>
+            <div className="body">Plan · Review · Rename</div>
+          </div>
+          <div className="row gap-10 center">
+            <span className="pill done">✓ plan</span>
+            <span className="pill now">review</span>
+            <span className="pill next">rename</span>
+            <ThemeBlob />
+          </div>
+        </div>
+
+        {/* Two columns: settings (left) | results preview (right) */}
+        <div className="grid-2 mt-16">
+          <div className="box">
+            <h4 className="h">Plan</h4>
+            <div className="body" style={{ marginBottom: 10 }}>Pick a folder, the rest is automatic.</div>
+
+            <div className="kv">
+              <span className="lbl">Photos</span>
+              <div className="field"><span className="grow">{SAMPLE_FOLDER}</span></div>
+              <button className="btn icon">…</button>
+            </div>
+
+            <div className="kv">
+              <span className="lbl">Save plan</span>
+              <div className="field muted"><span className="grow">same folder</span></div>
+              <button className="btn icon ghost">change</button>
+            </div>
+
+            <div className="kv">
+              <span className="lbl">Filename</span>
+              <div className="field muted"><span className="grow">rename-plan.json</span></div>
+              <button className="btn icon ghost">edit</button>
+            </div>
+
+            <div className="row mt-16 between center">
+              <span className="body" style={{ color: 'var(--ink-soft)' }}>2 subfolders found</span>
+              <button className="btn primary">Build plan</button>
+            </div>
+          </div>
+
+          <div className="box flat" style={{ background: 'rgba(255,255,255,.35)' }}>
+            <div className="row between center">
+              <h4 className="h">Preview</h4>
+              <span className="lbl">live</span>
+            </div>
+            <div className="body" style={{ marginBottom: 10 }}>
+              What the new names will look like:
+            </div>
+            <div className="col gap-8">
+              <div className="plan-card">
+                <div className="col">
+                  <span className="from strike">TestPhotos</span>
+                  <span className="to">2017-11-08 — 2025-08-17 — TestPhotos</span>
+                </div>
+                <span className="pill done">ok</span>
+              </div>
+              <div className="plan-card">
+                <div className="col">
+                  <span className="from strike">Holiday-Crete</span>
+                  <span className="to">2024-06-02 — 2024-06-14 — Holiday-Crete</span>
+                </div>
+                <span className="pill done">ok</span>
+              </div>
+              <div className="plan-card" style={{ background: '#fff7e8' }}>
+                <div className="col">
+                  <span className="from strike">Random</span>
+                  <span className="to">— Random</span>
+                </div>
+                <span className="pill warn">no dates</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <Anno style={{ top: 60, right: 18, width: 200 }}>
+          <b>Inline icon buttons</b>:<br/>
+          field + tiny browse.<br/>
+          No giant orange bars.
+          <span className="arrow">↙</span>
+        </Anno>
+        <Anno style={{ top: 280, right: 18, width: 200 }}>
+          Plan + filename:<br/>
+          <b>muted defaults</b>.<br/>
+          One click to override.
+          <span className="arrow">↙</span>
+        </Anno>
+        <Anno style={{ top: 500, right: 18, width: 200 }}>
+          Right column =<br/>
+          <b>live preview</b>.<br/>
+          Review built in.
+          <span className="arrow">↙</span>
+        </Anno>
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Direction D — Drop-in single screen, zero-config
+// ────────────────────────────────────────────────
+
+function DirectionD() {
+  return (
+    <div className="sheet">
+      <WinBar title="Direction D · drop & rename" />
+      <div className="canvas">
+        <div className="dir-stamp">D</div>
+
+        <div className="row between center wrap gap-12">
+          <h3 className="h">Renamer</h3>
+          <ThemeBlob />
+        </div>
+
+        {/* drop zone */}
+        <div className="drop mt-16">
+          <h2 className="h">Drop a folder here</h2>
+          <div className="body">…or <a className="scribble">browse</a> to pick one.</div>
+          <div className="lbl mt-8">we'll suggest new dated names</div>
+        </div>
+
+        {/* once a folder is chosen */}
+        <div className="box mt-16">
+          <div className="row between center wrap gap-10">
+            <div className="col">
+              <span className="lbl">Selected</span>
+              <span style={{ fontFamily: 'var(--hand-mono)', fontSize: 13 }}>{SAMPLE_FOLDER}</span>
+            </div>
+            <div className="row gap-8">
+              <button className="btn ghost sm">Change folder</button>
+              <button className="btn ghost sm">Advanced ▾</button>
+            </div>
+          </div>
+
+          <div className="col gap-8 mt-12">
+            <div className="plan-card">
+              <div className="col">
+                <span className="from strike">TestPhotos</span>
+                <span className="to">2017-11-08 — 2025-08-17 — TestPhotos</span>
+              </div>
+              <input type="checkbox" defaultChecked style={{ width: 20, height: 20 }}/>
+            </div>
+            <div className="plan-card">
+              <div className="col">
+                <span className="from strike">Holiday-Crete</span>
+                <span className="to">2024-06-02 — 2024-06-14 — Holiday-Crete</span>
+              </div>
+              <input type="checkbox" defaultChecked style={{ width: 20, height: 20 }}/>
+            </div>
+            <div className="plan-card" style={{ background: '#fff7e8' }}>
+              <div className="col">
+                <span className="from strike">Misc</span>
+                <span className="to ph-block" style={{ display: 'inline-block' }}>no dates found — skipped</span>
+              </div>
+              <input type="checkbox" style={{ width: 20, height: 20 }}/>
+            </div>
+          </div>
+
+          <div className="row between center mt-16 wrap gap-10">
+            <span className="body" style={{ color: 'var(--ink-soft)' }}>
+              2 of 3 folders selected · plan auto-saved next to photos
+            </span>
+            <button className="btn primary lg">Rename 2 folders</button>
+          </div>
+        </div>
+
+        <Anno style={{ top: 60, right: 18, width: 200 }}>
+          <b>One screen.</b><br/>
+          No steps, no plan file UI,<br/>
+          no review tab.
+          <span className="arrow">↙</span>
+        </Anno>
+        <Anno style={{ top: 280, right: 18, width: 200 }}>
+          Plan saved silently<br/>
+          beside photos.<br/>
+          <b>Advanced ▾</b> reveals<br/>
+          path overrides.
+          <span className="arrow">↙</span>
+        </Anno>
+        <Anno style={{ top: 520, right: 18, width: 200 }}>
+          Per-folder <b>checkboxes</b><br/>
+          + one rename button<br/>
+          that names its action.
+          <span className="arrow">↙</span>
+        </Anno>
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Copy comparison + structural notes
+// ────────────────────────────────────────────────
+
+function CopyTable() {
+  const rows = [
+    ['Page title', 'Rename your folders in three steps', 'Renamer'],
+    ['Subtitle', "Build a plan, review the changes, then rename the folders when you're ready.", 'Plan · Review · Rename'],
+    ['Step 1 title', 'Build a plan', 'Pick a folder'],
+    ['Step 1 sub', 'Choose your photo folder and where to save the plan, then review the folder names before anything changes.', '—'],
+    ['Section title', 'Choose folders', '—'],
+    ['Field 1 label', 'Photo folder', 'Photos'],
+    ['Field 2 label', 'Save folder', '(hidden by default — same folder)'],
+    ['Field 3 label', 'Plan file', '(hidden by default — rename-plan.json)'],
+    ['Helper line', 'Plan will be saved to C:\\Dev\\…\\rename-plan.json', 'Saved next to your photos'],
+    ['Big button', 'Choose photo folder', 'Browse…'],
+    ['Confirm button', 'Build plan', 'Build plan →'],
+    ['Step 2 sub', 'Load a saved plan and check the proposed folder names before anything is renamed.', 'Check the new names look right.'],
+    ['"Before you rename"', 'Created · Folder changes · Things to note', '2 changes · 0 notes'],
+    ['Step 3 title', 'Apply the plan', 'Rename'],
+    ['Step 3 sub', 'This step makes the folder name changes. Review the plan first, then run it when you are ready.', '—'],
+    ['Run button', 'Rename now', 'Rename 2 folders'],
+    ['Done state', 'Rename finished: 1 changed, 0 skipped, 0 failed.', '✓ Renamed 1 folder'],
+  ];
+  return (
+    <div className="box">
+      <h3 className="h">Copy: before → after</h3>
+      <div className="body" style={{ marginBottom: 10 }}>
+        Friendly but minimal. Each piece of UI says one thing.
+      </div>
+      <table className="copy-tbl">
+        <thead><tr><th>where</th><th>now</th><th>proposed</th></tr></thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td className="lbl" style={{ whiteSpace: 'nowrap' }}>{r[0]}</td>
+              <td className="old">{r[1]}</td>
+              <td className="new"><b>{r[2]}</b></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StructureNotes() {
+  return (
+    <div className="footer-notes">
+      <div className="note-card">
+        <b>Defaults in, fields out</b><br/>
+        Save folder defaults to the photo folder. Filename defaults to <code>rename-plan.json</code>. Both hidden behind "Advanced" — surface only on conflict.
+      </div>
+      <div className="note-card">
+        <b>No full-width orange</b><br/>
+        Browse becomes a small button beside the field. Only the <i>commit</i> action ("Build plan", "Rename") is colored, and right-aligned.
+      </div>
+      <div className="note-card">
+        <b>Cards over floaty rows</b><br/>
+        Each folder change is a self-contained card with from/to and a status pill. No wandering labels above loose values.
+      </div>
+      <div className="note-card">
+        <b>Page title shrinks</b><br/>
+        "Rename your folders in three steps" becomes a stepper. The H1 just says <b>Renamer</b> or the current step.
+      </div>
+      <div className="note-card">
+        <b>Sidebar → stepper or rail</b><br/>
+        The three-card sidebar takes too much room for what it says. A horizontal stepper or a thin numbered rail does the same job.
+      </div>
+      <div className="note-card">
+        <b>Theme toggle compact</b><br/>
+        Three radio buttons collapse to a single 3-dot pill (sun · moon · auto). One click cycles, hover names the mode.
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────
+// Top-level app
+// ────────────────────────────────────────────────
+
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "view": "all",
+  "style": "sketch",
+  "showAnnos": true
+}/*EDITMODE-END*/;
+
+function App() {
+  const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+  const [view, setView] = useState(t.view || 'all');
+
+  React.useEffect(() => {
+    document.body.classList.toggle('style-clean', t.style === 'clean');
+    document.body.classList.toggle('hide-annos', !t.showAnnos);
+  }, [t.style, t.showAnnos]);
+
+  // sync local view with tweak
+  React.useEffect(() => { setView(t.view || 'all'); }, [t.view]);
+
+  const setView2 = (v) => { setView(v); setTweak('view', v); };
+
+  const tabs = [
+    ['all', 'All four'],
+    ['A', 'A · One page'],
+    ['B', 'B · Wizard rail'],
+    ['C', 'C · Two-column'],
+    ['D', 'D · Drop & go'],
+    ['copy', 'Copy rewrites'],
+  ];
+
+  return (
+    <div className="page">
+      <div className="page-head">
+        <div className="col">
+          <div className="meta">Wireframes · v1 · low-fi</div>
+          <h1 className="page-title">Renamer — cleanup directions</h1>
+          <p className="page-sub">
+            Four ways to declutter the three-step flow. All directions: shrink the page title,
+            kill full-width orange buttons, default the save-folder + filename, and structure plan items as cards.
+          </p>
+        </div>
+        <div className="col gap-8" style={{ alignItems: 'flex-end' }}>
+          <div className="legend">
+            <span><span className="swatch s1"/>commit action</span>
+            <span><span className="swatch s2"/>done</span>
+            <span><span className="swatch s3"/>defaults</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="tabs" data-screen-label="00 Tabs">
+        {tabs.map(([id, label]) => (
+          <button key={id} className={`tab ${view === id ? 'on' : ''}`} onClick={() => setView2(id)}>
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {(view === 'all' || view === 'A') && (
+        <div data-screen-label="A One page" style={{ marginBottom: 28 }}>
+          <div className="dir-head">
+            <span className="dir-num">A</span>
+            <span className="dir-name">One page, smart defaults</span>
+            <div className="dir-tags">
+              <span className="pill">no sidebar</span>
+              <span className="pill">stepper</span>
+              <span className="pill">defaults hidden</span>
+            </div>
+          </div>
+          <div className="dir-desc">
+            Drop the sidebar entirely. Top stepper gives you the three steps at a glance.
+            Save folder + filename are defaulted and tucked into a "Change…" reveal.
+          </div>
+          <DirectionA />
+        </div>
+      )}
+
+      {(view === 'all' || view === 'B') && (
+        <div data-screen-label="B Wizard rail" style={{ marginBottom: 28 }}>
+          <div className="dir-head">
+            <span className="dir-num">B</span>
+            <span className="dir-name">Wizard with thin rail</span>
+            <div className="dir-tags">
+              <span className="pill">numbered rail</span>
+              <span className="pill">card list</span>
+              <span className="pill">stat strip</span>
+            </div>
+          </div>
+          <div className="dir-desc">
+            Sidebar shrinks to a 70px rail of numbered dots — keeps step nav, frees the canvas.
+            Stat strip replaces the "Created / Folder changes / Things to note" trio.
+            Plan items become cards with status pills.
+          </div>
+          <DirectionB />
+        </div>
+      )}
+
+      {(view === 'all' || view === 'C') && (
+        <div data-screen-label="C Two-column" style={{ marginBottom: 28 }}>
+          <div className="dir-head">
+            <span className="dir-num">C</span>
+            <span className="dir-name">Compact two-column</span>
+            <div className="dir-tags">
+              <span className="pill">inline buttons</span>
+              <span className="pill">live preview</span>
+              <span className="pill">muted defaults</span>
+            </div>
+          </div>
+          <div className="dir-desc">
+            Left = the (small) inputs, right = a live preview of proposed names.
+            Browse buttons live next to their fields. Plan + filename render as muted "you can edit, but you don't need to" rows.
+          </div>
+          <DirectionC />
+        </div>
+      )}
+
+      {(view === 'all' || view === 'D') && (
+        <div data-screen-label="D Drop and go" style={{ marginBottom: 28 }}>
+          <div className="dir-head">
+            <span className="dir-num">D</span>
+            <span className="dir-name">Drop & rename</span>
+            <div className="dir-tags">
+              <span className="pill">zero-config</span>
+              <span className="pill">checkboxes</span>
+              <span className="pill">advanced ▾</span>
+            </div>
+          </div>
+          <div className="dir-desc">
+            The boldest cut. No "plan" surface at all from the user's POV — drop a folder, see proposed names,
+            uncheck any you don't want, hit rename. The plan file still exists; it's just an implementation detail.
+            "Advanced" hides path overrides for the rare edge case.
+          </div>
+          <DirectionD />
+        </div>
+      )}
+
+      {(view === 'all' || view === 'copy') && (
+        <div data-screen-label="Copy rewrites" style={{ marginBottom: 28 }}>
+          <div className="dir-head">
+            <span className="dir-name">Copy rewrites</span>
+          </div>
+          <CopyTable />
+          <h3 className="h" style={{ marginTop: 24 }}>Structural moves (apply to all directions)</h3>
+          <StructureNotes />
+        </div>
+      )}
+
+      <TweaksPanel>
+        <TweakSection label="View" />
+        <TweakRadio
+          label="Direction"
+          value={t.view}
+          options={[
+            { value: 'all', label: 'All' },
+            { value: 'A', label: 'A' },
+            { value: 'B', label: 'B' },
+            { value: 'C', label: 'C' },
+            { value: 'D', label: 'D' },
+          ]}
+          onChange={(v) => setTweak('view', v)}
+        />
+        <TweakSection label="Style" />
+        <TweakRadio
+          label="Render"
+          value={t.style}
+          options={[
+            { value: 'sketch', label: 'Sketchy' },
+            { value: 'clean',  label: 'Clean' },
+          ]}
+          onChange={(v) => setTweak('style', v)}
+        />
+        <TweakToggle
+          label="Show annotations"
+          value={t.showAnnos}
+          onChange={(v) => setTweak('showAnnos', v)}
+        />
+      </TweaksPanel>
+
+      <style>{`
+        body.hide-annos .anno { display: none; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary

- Adds `335-ui-cleanup-design-baseline.md` capturing the v2 UI redesign direction (thin rail, inline browse buttons, smart defaults, card plan items, stat strip, compact theme toggle)
- Adds six dependent implementation slice specs: 340 thin rail, 350 inline browse buttons, 360 smart defaults, 370 plan items as cards, 380 stat strip + result banner, 390 compact theme toggle
- Adds design mockups (`docs/specs/mockups/`) as reference artifacts for the baseline
- Updates `docs/checklists/v1.md` with a new "UI cleanup v2" section (335–390, all unchecked)
- Updates `docs/specs/000-index.md` with entries for 335–390

## Test plan

- [ ] Docs-only change — no `src/**` edits
- [ ] `dotnet restore` / `dotnet build` / `dotnet test` pass on main after merge

Closes #335
