### PR TITLE
refactor(ui): 340 thin numbered rail

### DIFF
--- a/src/Renamer.Tests/UI/WorkflowRailItemTests.cs
+++ b/src/Renamer.Tests/UI/WorkflowRailItemTests.cs
@@ -1,0 +1,107 @@
+using Renamer.UI.Plans;
+using Renamer.UI.Resources.Strings;
+
+namespace Renamer.Tests.UI;
+
+public sealed class WorkflowRailItemTests
+{
+    [Fact]
+    public void TitleCharacters_ReturnsUppercasedNonWhitespaceChars()
+    {
+        var item = MakeItem(step: PlanWorkflowStep.GeneratePlan, title: "Build a plan");
+
+        var chars = item.TitleCharacters;
+
+        Assert.Equal(["B", "U", "I", "L", "D", "A", "P", "L", "A", "N"], chars);
+    }
+
+    [Fact]
+    public void TitleCharacters_TrimsLeadingAndTrailingWhitespace()
+    {
+        var item = MakeItem(title: "  Plan  ");
+
+        Assert.Equal(["P", "L", "A", "N"], item.TitleCharacters);
+    }
+
+    [Fact]
+    public void StepNumber_MapsEnumToOrdinal()
+    {
+        Assert.Equal(1, MakeItem(step: PlanWorkflowStep.GeneratePlan).StepNumber);
+        Assert.Equal(2, MakeItem(step: PlanWorkflowStep.PreviewPlan).StepNumber);
+        Assert.Equal(3, MakeItem(step: PlanWorkflowStep.ApplyPlan).StepNumber);
+    }
+
+    [Fact]
+    public void IndicatorState_DefaultsToNext()
+    {
+        var item = MakeItem();
+
+        Assert.Equal("Next", item.IndicatorState);
+    }
+
+    [Fact]
+    public void IndicatorState_WhenSelected_ReturnsNow()
+    {
+        var item = MakeItem();
+        item.IsSelected = true;
+
+        Assert.Equal("Now", item.IndicatorState);
+    }
+
+    [Fact]
+    public void IndicatorState_WhenStatusDone_ReturnsDone()
+    {
+        var item = MakeItem();
+        item.Status = PlanWorkflowStepStatus.Done;
+
+        Assert.Equal("Done", item.IndicatorState);
+    }
+
+    [Fact]
+    public void IndicatorState_WhenStatusError_ReturnsError()
+    {
+        var item = MakeItem();
+        item.Status = PlanWorkflowStepStatus.Error;
+
+        Assert.Equal("Error", item.IndicatorState);
+    }
+
+    [Fact]
+    public void IndicatorState_WhenSelectedAndDone_ReturnsNow()
+    {
+        var item = MakeItem();
+        item.IsSelected = true;
+        item.Status = PlanWorkflowStepStatus.Done;
+
+        Assert.Equal("Now", item.IndicatorState);
+    }
+
+    [Fact]
+    public void IndicatorState_RaisesPropertyChanged_WhenIsSelectedChanges()
+    {
+        var item = MakeItem();
+        var raised = new List<string?>();
+        item.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        item.IsSelected = true;
+
+        Assert.Contains(nameof(item.IndicatorState), raised);
+    }
+
+    [Fact]
+    public void IndicatorState_RaisesPropertyChanged_WhenStatusChanges()
+    {
+        var item = MakeItem();
+        var raised = new List<string?>();
+        item.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        item.Status = PlanWorkflowStepStatus.Done;
+
+        Assert.Contains(nameof(item.IndicatorState), raised);
+    }
+
+    private static PlanWorkflowStepItem MakeItem(
+        PlanWorkflowStep step = PlanWorkflowStep.GeneratePlan,
+        string title = "Plan") =>
+        new(step, title, AppStrings.StepGenerateDescription);
+}

--- a/src/Renamer.UI/MainPage.xaml
+++ b/src/Renamer.UI/MainPage.xaml
@@ -57,7 +57,7 @@
 
         <!-- Main content: rail left, workspace right -->
         <Grid Grid.Row="1"
-              ColumnDefinitions="280,*"
+              ColumnDefinitions="72,*"
               ColumnSpacing="0">
             <ScrollView>
                 <views:WorkflowRailView />

--- a/src/Renamer.UI/Plans/PlanWorkflowStepItem.cs
+++ b/src/Renamer.UI/Plans/PlanWorkflowStepItem.cs
@@ -25,6 +25,33 @@ public sealed class PlanWorkflowStepItem : INotifyPropertyChanged
 
     public string Description { get; }
 
+    public int StepNumber => Step switch
+    {
+        PlanWorkflowStep.GeneratePlan => 1,
+        PlanWorkflowStep.PreviewPlan => 2,
+        _ => 3
+    };
+
+    public IReadOnlyList<string> TitleCharacters =>
+        Title.Trim().ToUpperInvariant()
+             .Where(c => !char.IsWhiteSpace(c))
+             .Select(c => c.ToString())
+             .ToList();
+
+    public string IndicatorState
+    {
+        get
+        {
+            if (isSelected) return "Now";
+            return status switch
+            {
+                PlanWorkflowStepStatus.Done => "Done",
+                PlanWorkflowStepStatus.Error => "Error",
+                _ => "Next"
+            };
+        }
+    }
+
     public PlanWorkflowStepStatus Status
     {
         get => status;
@@ -34,6 +61,7 @@ public sealed class PlanWorkflowStepItem : INotifyPropertyChanged
             {
                 OnPropertyChanged(nameof(StatusText));
                 OnPropertyChanged(nameof(StatusColor));
+                OnPropertyChanged(nameof(IndicatorState));
             }
         }
     }
@@ -55,7 +83,11 @@ public sealed class PlanWorkflowStepItem : INotifyPropertyChanged
     public bool IsSelected
     {
         get => isSelected;
-        set => SetProperty(ref isSelected, value);
+        set
+        {
+            if (SetProperty(ref isSelected, value))
+                OnPropertyChanged(nameof(IndicatorState));
+        }
     }
 
     private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)

--- a/src/Renamer.UI/Views/WorkflowRailView.xaml
+++ b/src/Renamer.UI/Views/WorkflowRailView.xaml
@@ -2,156 +2,248 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:plans="clr-namespace:Renamer.UI.Plans"
-             xmlns:strings="clr-namespace:Renamer.UI.Resources.Strings"
              x:Class="Renamer.UI.Views.WorkflowRailView"
              x:DataType="plans:IPlanViewModel">
-    <VerticalStackLayout Spacing="16">
-        <Border Padding="16"
-                Margin="0,0,18,0"
-                Background="{DynamicResource BackgroundSecondary}">
-            <VerticalStackLayout Spacing="8">
-                <Label Text="{x:Static strings:AppStrings.WorkflowRailHeader}"
-                       FontSize="18"
-                       FontAttributes="Bold" />
-                <Label Text="{x:Static strings:AppStrings.WorkflowRailDescription}"
-                       FontSize="13"
-                       TextColor="{DynamicResource TextSecondary}" />
-            </VerticalStackLayout>
-        </Border>
+    <VerticalStackLayout Spacing="0"
+                         HorizontalOptions="Center"
+                         Padding="0,16,0,16">
 
-        <Border Padding="14"
-                Margin="0,0,18,0"
-                Stroke="{DynamicResource BorderPrimary}"
-                Background="{DynamicResource BackgroundSecondary}"
-                ZIndex="2">
-            <Border.StrokeShape>
-                <RoundRectangle CornerRadius="8" />
-            </Border.StrokeShape>
-            <Border.GestureRecognizers>
+        <!-- Step 1: Generate -->
+        <VerticalStackLayout HorizontalOptions="Center"
+                             Spacing="6">
+            <VerticalStackLayout.GestureRecognizers>
                 <TapGestureRecognizer Command="{Binding SelectStepCommand}"
                                       CommandParameter="{x:Static plans:PlanWorkflowStep.GeneratePlan}" />
-            </Border.GestureRecognizers>
-            <Border.Triggers>
-                <DataTrigger TargetType="Border"
-                             Binding="{Binding GenerateStep.IsSelected}"
-                             Value="True">
-                    <Setter Property="Margin" Value="0,0,-1,0" />
-                    <Setter Property="Padding" Value="14,14,33,14" />
-                    <Setter Property="StrokeShape">
-                        <RoundRectangle CornerRadius="8,0,8,0" />
-                    </Setter>
-                </DataTrigger>
-            </Border.Triggers>
-            <VerticalStackLayout Spacing="10">
-                <Grid ColumnDefinitions="*,Auto"
-                      ColumnSpacing="10">
-                    <Label Text="{Binding GenerateStep.Title}"
-                           FontSize="16"
-                           FontAttributes="Bold" />
-                    <Label Grid.Column="1"
-                           Text="{Binding GenerateStep.StatusText}"
-                           FontSize="11"
-                           FontAttributes="Bold"
-                           Padding="8,4"
-                           BackgroundColor="{DynamicResource BadgeBackground}"
-                           TextColor="{Binding GenerateStep.StatusColor}"
-                           HorizontalOptions="End"
-                           VerticalOptions="Start" />
-                </Grid>
-                <Label Text="{Binding GenerateStep.Description}"
-                       FontSize="13"
-                       TextColor="{DynamicResource TextSecondary}" />
-            </VerticalStackLayout>
-        </Border>
+            </VerticalStackLayout.GestureRecognizers>
 
-        <Border Padding="14"
-                Margin="0,0,18,0"
-                Stroke="{DynamicResource BorderPrimary}"
-                Background="{DynamicResource BackgroundSecondary}"
-                ZIndex="2">
-            <Border.StrokeShape>
-                <RoundRectangle CornerRadius="8" />
-            </Border.StrokeShape>
-            <Border.GestureRecognizers>
+            <Border WidthRequest="36"
+                    HeightRequest="36"
+                    HorizontalOptions="Center"
+                    StrokeThickness="2"
+                    Stroke="{DynamicResource BorderPrimary}"
+                    Background="Transparent"
+                    StrokeShape="Ellipse">
+                <Border.Triggers>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding GenerateStep.IndicatorState}"
+                                 Value="Now">
+                        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+                        <Setter Property="Stroke" Value="Transparent" />
+                    </DataTrigger>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding GenerateStep.IndicatorState}"
+                                 Value="Done">
+                        <Setter Property="Background" Value="{DynamicResource StatusSuccess}" />
+                        <Setter Property="Stroke" Value="Transparent" />
+                    </DataTrigger>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding GenerateStep.IndicatorState}"
+                                 Value="Error">
+                        <Setter Property="Stroke" Value="{DynamicResource StatusError}" />
+                    </DataTrigger>
+                </Border.Triggers>
+                <Label Text="{Binding GenerateStep.StepNumber, StringFormat='{0}'}"
+                       HorizontalOptions="Center"
+                       VerticalOptions="Center"
+                       FontSize="14"
+                       FontAttributes="Bold"
+                       TextColor="{DynamicResource TextMuted}">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding GenerateStep.IndicatorState}"
+                                     Value="Now">
+                            <Setter Property="TextColor" Value="{DynamicResource ButtonText}" />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding GenerateStep.IndicatorState}"
+                                     Value="Done">
+                            <Setter Property="Text" Value="✓" />
+                            <Setter Property="TextColor" Value="{DynamicResource ButtonText}" />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding GenerateStep.IndicatorState}"
+                                     Value="Error">
+                            <Setter Property="TextColor" Value="{DynamicResource StatusError}" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
+            </Border>
+
+            <VerticalStackLayout HorizontalOptions="Center"
+                                 Spacing="1"
+                                 BindableLayout.ItemsSource="{Binding GenerateStep.TitleCharacters}">
+                <BindableLayout.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <Label Text="{Binding}"
+                               FontSize="9"
+                               HorizontalOptions="Center"
+                               TextColor="{DynamicResource TextMuted}" />
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
+            </VerticalStackLayout>
+        </VerticalStackLayout>
+
+        <!-- Connector -->
+        <BoxView WidthRequest="2"
+                 HeightRequest="24"
+                 HorizontalOptions="Center"
+                 BackgroundColor="{DynamicResource BorderPrimary}" />
+
+        <!-- Step 2: Preview -->
+        <VerticalStackLayout HorizontalOptions="Center"
+                             Spacing="6">
+            <VerticalStackLayout.GestureRecognizers>
                 <TapGestureRecognizer Command="{Binding SelectStepCommand}"
                                       CommandParameter="{x:Static plans:PlanWorkflowStep.PreviewPlan}" />
-            </Border.GestureRecognizers>
-            <Border.Triggers>
-                <DataTrigger TargetType="Border"
-                             Binding="{Binding PreviewStep.IsSelected}"
-                             Value="True">
-                    <Setter Property="Margin" Value="0,0,-1,0" />
-                    <Setter Property="Padding" Value="14,14,33,14" />
-                    <Setter Property="StrokeShape">
-                        <RoundRectangle CornerRadius="8,0,8,0" />
-                    </Setter>
-                </DataTrigger>
-            </Border.Triggers>
-            <VerticalStackLayout Spacing="10">
-                <Grid ColumnDefinitions="*,Auto"
-                      ColumnSpacing="10">
-                    <Label Text="{Binding PreviewStep.Title}"
-                           FontSize="16"
-                           FontAttributes="Bold" />
-                    <Label Grid.Column="1"
-                           Text="{Binding PreviewStep.StatusText}"
-                           FontSize="11"
-                           FontAttributes="Bold"
-                           Padding="8,4"
-                           BackgroundColor="{DynamicResource BadgeBackground}"
-                           TextColor="{Binding PreviewStep.StatusColor}"
-                           HorizontalOptions="End"
-                           VerticalOptions="Start" />
-                </Grid>
-                <Label Text="{Binding PreviewStep.Description}"
-                       FontSize="13"
-                       TextColor="{DynamicResource TextSecondary}" />
-            </VerticalStackLayout>
-        </Border>
+            </VerticalStackLayout.GestureRecognizers>
 
-        <Border Padding="14"
-                Margin="0,0,18,0"
-                Stroke="{DynamicResource BorderPrimary}"
-                Background="{DynamicResource BackgroundSecondary}"
-                ZIndex="2">
-            <Border.StrokeShape>
-                <RoundRectangle CornerRadius="8" />
-            </Border.StrokeShape>
-            <Border.GestureRecognizers>
+            <Border WidthRequest="36"
+                    HeightRequest="36"
+                    HorizontalOptions="Center"
+                    StrokeThickness="2"
+                    Stroke="{DynamicResource BorderPrimary}"
+                    Background="Transparent"
+                    StrokeShape="Ellipse">
+                <Border.Triggers>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding PreviewStep.IndicatorState}"
+                                 Value="Now">
+                        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+                        <Setter Property="Stroke" Value="Transparent" />
+                    </DataTrigger>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding PreviewStep.IndicatorState}"
+                                 Value="Done">
+                        <Setter Property="Background" Value="{DynamicResource StatusSuccess}" />
+                        <Setter Property="Stroke" Value="Transparent" />
+                    </DataTrigger>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding PreviewStep.IndicatorState}"
+                                 Value="Error">
+                        <Setter Property="Stroke" Value="{DynamicResource StatusError}" />
+                    </DataTrigger>
+                </Border.Triggers>
+                <Label Text="{Binding PreviewStep.StepNumber, StringFormat='{0}'}"
+                       HorizontalOptions="Center"
+                       VerticalOptions="Center"
+                       FontSize="14"
+                       FontAttributes="Bold"
+                       TextColor="{DynamicResource TextMuted}">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding PreviewStep.IndicatorState}"
+                                     Value="Now">
+                            <Setter Property="TextColor" Value="{DynamicResource ButtonText}" />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding PreviewStep.IndicatorState}"
+                                     Value="Done">
+                            <Setter Property="Text" Value="✓" />
+                            <Setter Property="TextColor" Value="{DynamicResource ButtonText}" />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding PreviewStep.IndicatorState}"
+                                     Value="Error">
+                            <Setter Property="TextColor" Value="{DynamicResource StatusError}" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
+            </Border>
+
+            <VerticalStackLayout HorizontalOptions="Center"
+                                 Spacing="1"
+                                 BindableLayout.ItemsSource="{Binding PreviewStep.TitleCharacters}">
+                <BindableLayout.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <Label Text="{Binding}"
+                               FontSize="9"
+                               HorizontalOptions="Center"
+                               TextColor="{DynamicResource TextMuted}" />
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
+            </VerticalStackLayout>
+        </VerticalStackLayout>
+
+        <!-- Connector -->
+        <BoxView WidthRequest="2"
+                 HeightRequest="24"
+                 HorizontalOptions="Center"
+                 BackgroundColor="{DynamicResource BorderPrimary}" />
+
+        <!-- Step 3: Apply -->
+        <VerticalStackLayout HorizontalOptions="Center"
+                             Spacing="6">
+            <VerticalStackLayout.GestureRecognizers>
                 <TapGestureRecognizer Command="{Binding SelectStepCommand}"
                                       CommandParameter="{x:Static plans:PlanWorkflowStep.ApplyPlan}" />
-            </Border.GestureRecognizers>
-            <Border.Triggers>
-                <DataTrigger TargetType="Border"
-                             Binding="{Binding ApplyStep.IsSelected}"
-                             Value="True">
-                    <Setter Property="Margin" Value="0,0,-1,0" />
-                    <Setter Property="Padding" Value="14,14,33,14" />
-                    <Setter Property="StrokeShape">
-                        <RoundRectangle CornerRadius="8,0,8,0" />
-                    </Setter>
-                </DataTrigger>
-            </Border.Triggers>
-            <VerticalStackLayout Spacing="10">
-                <Grid ColumnDefinitions="*,Auto"
-                      ColumnSpacing="10">
-                    <Label Text="{Binding ApplyStep.Title}"
-                           FontSize="16"
-                           FontAttributes="Bold" />
-                    <Label Grid.Column="1"
-                           Text="{Binding ApplyStep.StatusText}"
-                           FontSize="11"
-                           FontAttributes="Bold"
-                           Padding="8,4"
-                           BackgroundColor="{DynamicResource BadgeBackground}"
-                           TextColor="{Binding ApplyStep.StatusColor}"
-                           HorizontalOptions="End"
-                           VerticalOptions="Start" />
-                </Grid>
-                <Label Text="{Binding ApplyStep.Description}"
-                       FontSize="13"
-                       TextColor="{DynamicResource TextSecondary}" />
+            </VerticalStackLayout.GestureRecognizers>
+
+            <Border WidthRequest="36"
+                    HeightRequest="36"
+                    HorizontalOptions="Center"
+                    StrokeThickness="2"
+                    Stroke="{DynamicResource BorderPrimary}"
+                    Background="Transparent"
+                    StrokeShape="Ellipse">
+                <Border.Triggers>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding ApplyStep.IndicatorState}"
+                                 Value="Now">
+                        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+                        <Setter Property="Stroke" Value="Transparent" />
+                    </DataTrigger>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding ApplyStep.IndicatorState}"
+                                 Value="Done">
+                        <Setter Property="Background" Value="{DynamicResource StatusSuccess}" />
+                        <Setter Property="Stroke" Value="Transparent" />
+                    </DataTrigger>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding ApplyStep.IndicatorState}"
+                                 Value="Error">
+                        <Setter Property="Stroke" Value="{DynamicResource StatusError}" />
+                    </DataTrigger>
+                </Border.Triggers>
+                <Label Text="{Binding ApplyStep.StepNumber, StringFormat='{0}'}"
+                       HorizontalOptions="Center"
+                       VerticalOptions="Center"
+                       FontSize="14"
+                       FontAttributes="Bold"
+                       TextColor="{DynamicResource TextMuted}">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding ApplyStep.IndicatorState}"
+                                     Value="Now">
+                            <Setter Property="TextColor" Value="{DynamicResource ButtonText}" />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding ApplyStep.IndicatorState}"
+                                     Value="Done">
+                            <Setter Property="Text" Value="✓" />
+                            <Setter Property="TextColor" Value="{DynamicResource ButtonText}" />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding ApplyStep.IndicatorState}"
+                                     Value="Error">
+                            <Setter Property="TextColor" Value="{DynamicResource StatusError}" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
+            </Border>
+
+            <VerticalStackLayout HorizontalOptions="Center"
+                                 Spacing="1"
+                                 BindableLayout.ItemsSource="{Binding ApplyStep.TitleCharacters}">
+                <BindableLayout.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <Label Text="{Binding}"
+                               FontSize="9"
+                               HorizontalOptions="Center"
+                               TextColor="{DynamicResource TextMuted}" />
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
             </VerticalStackLayout>
-        </Border>
+        </VerticalStackLayout>
+
     </VerticalStackLayout>
 </ContentView>


### PR DESCRIPTION
 ## Summary
  - Rewrites `WorkflowRailView.xaml` as a 72px thin rail with circular numbered indicators, `VisualStateManager` states (`Now`/`Done`/`Error`/`Next`), stacked-letter vertical
  labels, and connector lines between steps
  - Adds `TitleCharacters` and `IndicatorState` properties to `PlanWorkflowStepItem` to support the new bindings
  - Updates `MainPage.xaml` rail column width from `280` to `72`

  ## Test plan
  - [x] `WorkflowRailItemTests` — `TitleCharacters` derivation, `StepNumber` mapping, `IndicatorState` transitions and `PropertyChanged` notifications
  - [x] Full suite: 104 tests passing (`dotnet test Renamer.sln`)

  Closes #50