### PR TITLE
refactor(ui): 350 inline browse buttons

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -41,7 +41,7 @@
 
 ## UI cleanup v2 (one PR per item)
 - [ ] 335 UI cleanup design baseline (`docs/specs/335-ui-cleanup-design-baseline.md`)
-- [ ] 340 Thin rail redesign (`docs/specs/340-thin-rail-redesign.md`)
+- [x] 340 Thin rail redesign (`docs/specs/340-thin-rail-redesign.md`)
 - [ ] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
 - [ ] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
 - [ ] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)

--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -42,7 +42,7 @@
 ## UI cleanup v2 (one PR per item)
 - [x] 335 UI cleanup design baseline (`docs/specs/335-ui-cleanup-design-baseline.md`)
 - [x] 340 Thin rail redesign (`docs/specs/340-thin-rail-redesign.md`)
-- [ ] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
+- [x] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
 - [ ] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
 - [ ] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)
 - [ ] 380 Stat strip and result banner (`docs/specs/380-stat-strip-and-result-banner.md`)

--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -40,7 +40,7 @@
 - [x] 330 Apply copy refresh (`docs/specs/330-apply-copy-refresh.md`)
 
 ## UI cleanup v2 (one PR per item)
-- [ ] 335 UI cleanup design baseline (`docs/specs/335-ui-cleanup-design-baseline.md`)
+- [x] 335 UI cleanup design baseline (`docs/specs/335-ui-cleanup-design-baseline.md`)
 - [x] 340 Thin rail redesign (`docs/specs/340-thin-rail-redesign.md`)
 - [ ] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
 - [ ] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -45,8 +45,10 @@ When opening a PR for a slice:
    - use `Refs #<issue-number>` only when the PR is partial or non-closing
 3. Confirm the linked issue is in `In Progress` before requesting review.
 4. Keep the PR scoped to the slice spec and acceptance checks only.
-5. After merge:
-   - update `docs/checklists/v1.md`
+5. Before pushing the branch, commit the checklist update as part of the slice:
+   - mark the active item in `docs/checklists/v1.md` as `[x]`
+   - stage and commit it alongside the implementation files — do not leave it for after merge
+6. After merge:
    - confirm the GitHub issue is closed by the PR merge
 
 ## Notes

--- a/docs/specs/100-slice-template.md
+++ b/docs/specs/100-slice-template.md
@@ -42,12 +42,13 @@ One-sentence outcome.
 1. Branch from current `main` using the conventional commit type as prefix (for example `feat/xxx-slice-name` or `refactor/xxx-slice-name`). See `docs/specs/070-engineering-contract.md` for type vocabulary and branch naming rules.
 2. Keep one slice per branch and one branch per PR.
 3. Commit only files related to this slice.
-4. If a matching GitHub issue exists, ensure it is `In Progress` before opening the PR.
-5. Open PR back into `main` with slice ID in title/body.
-6. Link the corresponding issue in the PR body:
+4. Before pushing: mark this slice's item in `docs/checklists/v1.md` as `[x]` and include it in the commit. Do not leave the checklist update for after merge.
+5. If a matching GitHub issue exists, ensure it is `In Progress` before opening the PR.
+6. Open PR back into `main` with slice ID in title/body.
+7. Link the corresponding issue in the PR body:
    - use `Closes #<issue-number>` when the PR completes the slice
    - use `Refs #<issue-number>` only for partial work
-7. Include the slice ID in PR title and body.
+8. Include the slice ID in PR title and body.
 
 ## Acceptance checks
 
@@ -72,7 +73,7 @@ Acceptance checks are human-verified unless a runnable command is explicitly spe
 ## Definition of Done
 - Acceptance checks in this slice are satisfied.
 - Tests listed in this slice are implemented and pass locally.
-- Checklist item for this slice is updated.
+- Checklist item for this slice is committed on the slice branch before push (not after merge).
 - Branch pre-implementation gate completed before first code edit.
 - Branch name follows `<type>/` (conventional commit type) and maps to this slice ID.
 - PR scope is limited to this slice (no unrelated refactors).

--- a/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
@@ -139,6 +139,8 @@ namespace Renamer.UI.Resources.Strings
         internal static string ApplyDescription => ResourceManager.GetString("ApplyDescription", resourceCulture)!;
         internal static string ApplyPlanArtifactSectionHeader => ResourceManager.GetString("ApplyPlanArtifactSectionHeader", resourceCulture)!;
         internal static string ApplyPlanArtifactInstructions => ResourceManager.GetString("ApplyPlanArtifactInstructions", resourceCulture)!;
+        internal static string BrowseButtonGlyph => ResourceManager.GetString("BrowseButtonGlyph", resourceCulture)!;
+
         internal static string ApplyButtonBrowse => ResourceManager.GetString("ApplyButtonBrowse", resourceCulture)!;
         internal static string ApplyButtonLoadPlan => ResourceManager.GetString("ApplyButtonLoadPlan", resourceCulture)!;
         internal static string ApplyErrorHeading => ResourceManager.GetString("ApplyErrorHeading", resourceCulture)!;

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -225,6 +225,10 @@
     <value>Build plan</value>
     <comment/>
   </data>
+  <data name="BrowseButtonGlyph" xml:space="preserve">
+    <value>…</value>
+    <comment>Ellipsis glyph shown on inline browse buttons beside path fields</comment>
+  </data>
   <data name="GenerateStatusDefault" xml:space="preserve">
     <value>Choose a photo folder and a save folder to build a plan.</value>
     <comment/>

--- a/src/Renamer.UI/Resources/Styles/Styles.xaml
+++ b/src/Renamer.UI/Resources/Styles/Styles.xaml
@@ -177,6 +177,34 @@
         <Setter Property="TextColor" Value="{DynamicResource TextPrimary}" />
     </Style>
 
+    <Style TargetType="Button" x:Key="BrowseButton">
+        <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
+        <Setter Property="TextColor" Value="{DynamicResource TextSecondary}" />
+        <Setter Property="BorderColor" Value="{DynamicResource BorderPrimary}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="WidthRequest" Value="36" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="MinimumHeightRequest" Value="44" />
+        <Setter Property="MinimumWidthRequest" Value="36" />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="{DynamicResource TextMuted}" />
+                            <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
     <Style TargetType="Label" x:Key="Headline">
         <Setter Property="TextColor" Value="{DynamicResource TextPrimary}" />
         <Setter Property="FontSize" Value="32" />

--- a/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
@@ -29,7 +29,7 @@
                            Placeholder="{x:Static strings:AppStrings.PreviewPlaceholder}"
                            ClearButtonVisibility="WhileEditing" />
                     <Button Grid.Column="1"
-                            Style="{StaticResource BrowseButton}"
+                            Style="{DynamicResource BrowseButton}"
                             Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
                             Command="{Binding BrowsePlanCommand}"
                             AutomationProperties.Name="{x:Static strings:AppStrings.ApplyButtonBrowse}"

--- a/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
@@ -23,12 +23,19 @@
                        FontAttributes="Bold" />
                 <Label Text="{x:Static strings:AppStrings.ApplyPlanArtifactInstructions}"
                        FontSize="13" />
-                <Entry Text="{Binding PlanPath}"
-                       Placeholder="{x:Static strings:AppStrings.PreviewPlaceholder}"
-                       ClearButtonVisibility="WhileEditing" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                    <Entry Grid.Column="0"
+                           Text="{Binding PlanPath}"
+                           Placeholder="{x:Static strings:AppStrings.PreviewPlaceholder}"
+                           ClearButtonVisibility="WhileEditing" />
+                    <Button Grid.Column="1"
+                            Style="{StaticResource BrowseButton}"
+                            Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
+                            Command="{Binding BrowsePlanCommand}"
+                            AutomationProperties.Name="{x:Static strings:AppStrings.ApplyButtonBrowse}"
+                            ToolTipProperties.Text="{x:Static strings:AppStrings.ApplyButtonBrowse}" />
+                </Grid>
                 <HorizontalStackLayout Spacing="10">
-                    <Button Text="{x:Static strings:AppStrings.ApplyButtonBrowse}"
-                            Command="{Binding BrowsePlanCommand}" />
                     <Button Text="{x:Static strings:AppStrings.ApplyButtonLoadPlan}"
                             Command="{Binding LoadPreviewCommand}" />
                     <ActivityIndicator IsRunning="{Binding IsLoading}"

--- a/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
@@ -32,7 +32,7 @@
                                Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderRootFolder}"
                                ClearButtonVisibility="WhileEditing" />
                         <Button Grid.Column="1"
-                                Style="{StaticResource BrowseButton}"
+                                Style="{DynamicResource BrowseButton}"
                                 Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
                                 Command="{Binding BrowseGenerationRootCommand}"
                                 AutomationProperties.Name="{x:Static strings:AppStrings.GenerateBrowseRootFolder}"
@@ -49,7 +49,7 @@
                                Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderOutputFolder}"
                                ClearButtonVisibility="WhileEditing" />
                         <Button Grid.Column="1"
-                                Style="{StaticResource BrowseButton}"
+                                Style="{DynamicResource BrowseButton}"
                                 Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
                                 Command="{Binding BrowseGenerationOutputDirectoryCommand}"
                                 AutomationProperties.Name="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}"

--- a/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
@@ -26,21 +26,35 @@
                 <VerticalStackLayout Spacing="6">
                     <Label Text="{x:Static strings:AppStrings.GenerateLabelRootFolder}"
                            FontAttributes="Bold" />
-                    <Entry Text="{Binding GenerationRootPath}"
-                           Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderRootFolder}"
-                           ClearButtonVisibility="WhileEditing" />
-                    <Button Text="{x:Static strings:AppStrings.GenerateBrowseRootFolder}"
-                            Command="{Binding BrowseGenerationRootCommand}" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                        <Entry Grid.Column="0"
+                               Text="{Binding GenerationRootPath}"
+                               Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderRootFolder}"
+                               ClearButtonVisibility="WhileEditing" />
+                        <Button Grid.Column="1"
+                                Style="{StaticResource BrowseButton}"
+                                Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
+                                Command="{Binding BrowseGenerationRootCommand}"
+                                AutomationProperties.Name="{x:Static strings:AppStrings.GenerateBrowseRootFolder}"
+                                ToolTipProperties.Text="{x:Static strings:AppStrings.GenerateBrowseRootFolder}" />
+                    </Grid>
                 </VerticalStackLayout>
 
                 <VerticalStackLayout Spacing="6">
                     <Label Text="{x:Static strings:AppStrings.GenerateLabelOutputFolder}"
                            FontAttributes="Bold" />
-                    <Entry Text="{Binding GenerationOutputDirectoryPath}"
-                           Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderOutputFolder}"
-                           ClearButtonVisibility="WhileEditing" />
-                    <Button Text="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}"
-                            Command="{Binding BrowseGenerationOutputDirectoryCommand}" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                        <Entry Grid.Column="0"
+                               Text="{Binding GenerationOutputDirectoryPath}"
+                               Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderOutputFolder}"
+                               ClearButtonVisibility="WhileEditing" />
+                        <Button Grid.Column="1"
+                                Style="{StaticResource BrowseButton}"
+                                Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
+                                Command="{Binding BrowseGenerationOutputDirectoryCommand}"
+                                AutomationProperties.Name="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}"
+                                ToolTipProperties.Text="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}" />
+                    </Grid>
                 </VerticalStackLayout>
 
                 <VerticalStackLayout Spacing="6">


### PR DESCRIPTION
## Summary
- Adds reusable `BrowseButton` style (36px, muted secondary, `DynamicResource` lookup)
- Refactors path `Entry` fields in `GenerateWorkspaceView` and `ApplyWorkspaceView` to `Grid("*,Auto")` with inline browse button in column 1
- `AutomationProperties.Name` and `ToolTipProperties.Text` bound to existing `Browse*` resource keys
- Adds `BrowseButtonGlyph` ("…") string resource — no hard-coded display text in XAML
- `ApplyButtonBrowse` removed from `HorizontalStackLayout`; `LoadPlan` remains the sole primary action

## Test plan
- [x] `dotnet build Renamer.sln` — passes
- [x] `dotnet test Renamer.sln` — 104 tests pass

Closes #51
