### PR TITLE
feat(ui): 360 plan file smart defaults

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -43,7 +43,7 @@
 - [x] 335 UI cleanup design baseline (`docs/specs/335-ui-cleanup-design-baseline.md`)
 - [x] 340 Thin rail redesign (`docs/specs/340-thin-rail-redesign.md`)
 - [x] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
-- [ ] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
+- [x] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
 - [ ] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)
 - [ ] 380 Stat strip and result banner (`docs/specs/380-stat-strip-and-result-banner.md`)
 - [ ] 390 Compact theme toggle (`docs/specs/390-compact-theme-toggle.md`)

--- a/src/Renamer.Tests/UI/PlanViewModelDefaultsTests.cs
+++ b/src/Renamer.Tests/UI/PlanViewModelDefaultsTests.cs
@@ -1,0 +1,159 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Renamer.Core.Contracts;
+using Renamer.Core.Execution;
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
+using Renamer.UI.Plans;
+using Renamer.UI.Resources.Strings;
+
+namespace Renamer.Tests.UI;
+
+public sealed class PlanViewModelDefaultsTests
+{
+    [Fact]
+    public void PlanFileName_DefaultsToRenameJson()
+    {
+        var vm = MakeViewModel();
+
+        Assert.Equal(AppStrings.DefaultPlanFileName, vm.PlanFileName);
+    }
+
+    [Fact]
+    public void GenerationOutputDirectoryPath_WhenRootSet_AutoFillsToRoot()
+    {
+        var vm = MakeViewModel();
+
+        vm.GenerationRootPath = "/photos";
+
+        Assert.Equal("/photos", vm.GenerationOutputDirectoryPath);
+    }
+
+    [Fact]
+    public void GenerationOutputDirectoryPath_WhenRootChanges_FollowsRootIfNotOverridden()
+    {
+        var vm = MakeViewModel();
+        vm.GenerationRootPath = "/photos";
+
+        vm.GenerationRootPath = "/pictures";
+
+        Assert.Equal("/pictures", vm.GenerationOutputDirectoryPath);
+    }
+
+    [Fact]
+    public async Task GenerationOutputDirectoryPath_WhenUserBrowses_IsPreservedOnRootChange()
+    {
+        var vm = MakeViewModel(outputPickerResult: "/custom/output");
+        vm.GenerationRootPath = "/photos";
+
+        await vm.BrowseGenerationOutputDirectoryAsync();
+        vm.GenerationRootPath = "/pictures";
+
+        Assert.Equal("/custom/output", vm.GenerationOutputDirectoryPath);
+    }
+
+    [Fact]
+    public void HasAdvancedOverrides_DefaultsToFalse()
+    {
+        var vm = MakeViewModel();
+
+        Assert.False(vm.HasAdvancedOverrides);
+    }
+
+    [Fact]
+    public void HasAdvancedOverrides_WhenOutputAutoFilled_RemainsFlase()
+    {
+        var vm = MakeViewModel();
+
+        vm.GenerationRootPath = "/photos";
+
+        Assert.False(vm.HasAdvancedOverrides);
+    }
+
+    [Fact]
+    public async Task HasAdvancedOverrides_WhenUserBrowsesOutput_BecomesTrue()
+    {
+        var vm = MakeViewModel(outputPickerResult: "/custom/output");
+
+        await vm.BrowseGenerationOutputDirectoryAsync();
+
+        Assert.True(vm.HasAdvancedOverrides);
+    }
+
+    [Fact]
+    public void HasAdvancedOverrides_WhenPlanFileNameChanged_BecomesTrue()
+    {
+        var vm = MakeViewModel();
+
+        vm.PlanFileName = "my-plan.json";
+
+        Assert.True(vm.HasAdvancedOverrides);
+    }
+
+    [Fact]
+    public void HasAdvancedOverrides_RaisesPropertyChanged_WhenOutputOverridden()
+    {
+        var vm = MakeViewModel();
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.GenerationOutputDirectoryPath = "/custom/output";
+
+        Assert.Contains(nameof(vm.HasAdvancedOverrides), raised);
+    }
+
+    [Fact]
+    public void HasAdvancedOverrides_RaisesPropertyChanged_WhenFileNameOverridden()
+    {
+        var vm = MakeViewModel();
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.PlanFileName = "my-plan.json";
+
+        Assert.Contains(nameof(vm.HasAdvancedOverrides), raised);
+    }
+
+    private static PlanViewModel MakeViewModel(string? outputPickerResult = null) =>
+        new(
+            new FakePlanBuilder(),
+            new FakePlanSerializer(),
+            new FakePlanFilePicker(),
+            new FakeFolderPathPicker(outputPickerResult),
+            new FakeRootPathOpener(),
+            new FakeApplyEngine(),
+            NullLogger<PlanViewModel>.Instance);
+
+    private sealed class FakePlanBuilder : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => throw new NotImplementedException();
+    }
+
+    private sealed class FakePlanSerializer : IPlanSerializer
+    {
+        public RenamePlan Read(string inputPath) => throw new NotImplementedException();
+        public void Write(string outputPath, RenamePlan plan) => throw new NotImplementedException();
+    }
+
+    private sealed class FakePlanFilePicker : IPlanFilePicker
+    {
+        public Task<string?> PickPlanPathAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private sealed class FakeFolderPathPicker(string? result) : IFolderPathPicker
+    {
+        public Task<string?> PickFolderPathAsync(string title, CancellationToken cancellationToken = default) =>
+            Task.FromResult(result);
+    }
+
+    private sealed class FakeRootPathOpener : IRootPathOpener
+    {
+        public Task OpenAsync(string directoryPath, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class FakeApplyEngine : IApplyEngine
+    {
+        public RenameReport Execute(RenamePlan plan) => throw new NotImplementedException();
+    }
+}

--- a/src/Renamer.UI/Plans/IPlanViewModel.cs
+++ b/src/Renamer.UI/Plans/IPlanViewModel.cs
@@ -39,6 +39,8 @@ public interface IPlanViewModel : INotifyPropertyChanged
 
     bool CanGenerate { get; }
 
+    bool HasAdvancedOverrides { get; }
+
     string PlanPath { get; set; }
 
     string StatusMessage { get; }

--- a/src/Renamer.UI/Plans/PlanViewModel.cs
+++ b/src/Renamer.UI/Plans/PlanViewModel.cs
@@ -29,7 +29,7 @@ public sealed class PlanViewModel : IPlanViewModel
     private bool hasGeneratedPlan;
     private string generationRootPath = string.Empty;
     private string generationOutputDirectoryPath = string.Empty;
-    private string planFileName = "rename-plan.json";
+    private string planFileName = AppStrings.DefaultPlanFileName;
     private string generationStatusMessage = AppStrings.GenerateStatusDefault;
     private string? generationErrorTitle;
     private string? generationErrorMessage;
@@ -57,6 +57,7 @@ public sealed class PlanViewModel : IPlanViewModel
     private bool hasApplyReport;
     private bool isAutoUpdatingGenerationOutputDirectory;
     private string? autoFilledGenerationOutputDirectoryPath;
+    private bool planFileNameOverridden;
 
     public PlanViewModel(
         IPlanBuilder planBuilder,
@@ -120,6 +121,7 @@ public sealed class PlanViewModel : IPlanViewModel
         {
             if (SetProperty(ref generationRootPath, value))
             {
+                TryAutoFillGenerationOutputDirectory(value);
                 OnPropertyChanged(nameof(CanGenerate));
             }
         }
@@ -139,6 +141,7 @@ public sealed class PlanViewModel : IPlanViewModel
 
                 OnPropertyChanged(nameof(GeneratedPlanPathPreview));
                 OnPropertyChanged(nameof(CanGenerate));
+                OnPropertyChanged(nameof(HasAdvancedOverrides));
             }
         }
     }
@@ -150,8 +153,10 @@ public sealed class PlanViewModel : IPlanViewModel
         {
             if (SetProperty(ref planFileName, value))
             {
+                planFileNameOverridden = true;
                 OnPropertyChanged(nameof(GeneratedPlanPathPreview));
                 OnPropertyChanged(nameof(CanGenerate));
+                OnPropertyChanged(nameof(HasAdvancedOverrides));
             }
         }
     }
@@ -201,6 +206,10 @@ public sealed class PlanViewModel : IPlanViewModel
         !string.IsNullOrWhiteSpace(GenerationRootPath) &&
         !string.IsNullOrWhiteSpace(GenerationOutputDirectoryPath) &&
         !string.IsNullOrWhiteSpace(PlanFileName);
+
+    public bool HasAdvancedOverrides =>
+        (autoFilledGenerationOutputDirectoryPath == null && !string.IsNullOrWhiteSpace(generationOutputDirectoryPath)) ||
+        planFileNameOverridden;
 
     public string PlanPath
     {
@@ -387,7 +396,6 @@ public sealed class PlanViewModel : IPlanViewModel
         }
 
         GenerationRootPath = selectedPath;
-        TryAutoFillGenerationOutputDirectory(selectedPath);
         ClearGenerationError();
         GenerationStatusMessage = string.Format(AppStrings.GenerateStatusRootSelected, Path.GetFileName(selectedPath));
     }

--- a/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
@@ -72,6 +72,12 @@ namespace Renamer.UI.Resources.Strings
         internal static string GenerateLabelGeneratedPlanPath => ResourceManager.GetString("GenerateLabelGeneratedPlanPath", resourceCulture)!;
         internal static string GenerateButtonGenerateAndLoad => ResourceManager.GetString("GenerateButtonGenerateAndLoad", resourceCulture)!;
 
+        internal static string DefaultPlanFileName => ResourceManager.GetString("DefaultPlanFileName", resourceCulture)!;
+
+        internal static string GenerateAdvancedDisclosureLabel => ResourceManager.GetString("GenerateAdvancedDisclosureLabel", resourceCulture)!;
+
+        internal static string GenerateAdvancedDisclosureHelpCollapsed => ResourceManager.GetString("GenerateAdvancedDisclosureHelpCollapsed", resourceCulture)!;
+
         internal static string GenerateStatusDefault => ResourceManager.GetString("GenerateStatusDefault", resourceCulture)!;
         internal static string GenerateStatusRootCanceled => ResourceManager.GetString("GenerateStatusRootCanceled", resourceCulture)!;
         internal static string GenerateStatusRootSelected => ResourceManager.GetString("GenerateStatusRootSelected", resourceCulture)!;

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -225,6 +225,18 @@
     <value>Build plan</value>
     <comment/>
   </data>
+  <data name="DefaultPlanFileName" xml:space="preserve">
+    <value>rename-plan.json</value>
+    <comment/>
+  </data>
+  <data name="GenerateAdvancedDisclosureLabel" xml:space="preserve">
+    <value>Advanced</value>
+    <comment/>
+  </data>
+  <data name="GenerateAdvancedDisclosureHelpCollapsed" xml:space="preserve">
+    <value>Plan will be saved beside your photos.</value>
+    <comment/>
+  </data>
   <data name="BrowseButtonGlyph" xml:space="preserve">
     <value>…</value>
     <comment>Ellipsis glyph shown on inline browse buttons beside path fields</comment>

--- a/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
@@ -40,38 +40,53 @@
                     </Grid>
                 </VerticalStackLayout>
 
-                <VerticalStackLayout Spacing="6">
-                    <Label Text="{x:Static strings:AppStrings.GenerateLabelOutputFolder}"
-                           FontAttributes="Bold" />
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                        <Entry Grid.Column="0"
-                               Text="{Binding GenerationOutputDirectoryPath}"
-                               Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderOutputFolder}"
-                               ClearButtonVisibility="WhileEditing" />
-                        <Button Grid.Column="1"
-                                Style="{DynamicResource BrowseButton}"
-                                Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
-                                Command="{Binding BrowseGenerationOutputDirectoryCommand}"
-                                AutomationProperties.Name="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}"
-                                ToolTipProperties.Text="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}" />
-                    </Grid>
-                </VerticalStackLayout>
-
-                <VerticalStackLayout Spacing="6">
-                    <Label Text="{x:Static strings:AppStrings.GenerateLabelPlanFileName}"
-                           FontAttributes="Bold" />
-                    <Entry Text="{Binding PlanFileName}"
-                           Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderPlanFileName}"
-                           ClearButtonVisibility="WhileEditing" />
-                </VerticalStackLayout>
-
                 <VerticalStackLayout Spacing="4">
-                    <Label Text="{x:Static strings:AppStrings.GenerateLabelGeneratedPlanPath}"
-                           FontAttributes="Bold" />
-                    <Label Text="{Binding GeneratedPlanPathPreview}"
+                    <Label Text="{x:Static strings:AppStrings.GenerateAdvancedDisclosureHelpCollapsed}"
+                           x:Name="AdvancedCollapsedHint"
                            FontSize="12"
-                           LineBreakMode="WordWrap"
-                           TextColor="{DynamicResource TextLink}" />
+                           TextColor="{DynamicResource TextSecondary}" />
+                    <Button x:Name="AdvancedToggle"
+                            Text="{x:Static strings:AppStrings.GenerateAdvancedDisclosureLabel}"
+                            Clicked="OnAdvancedToggleClicked"
+                            HorizontalOptions="Start" />
+                </VerticalStackLayout>
+
+                <VerticalStackLayout x:Name="AdvancedPanel"
+                                     Spacing="12"
+                                     IsVisible="False">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="{x:Static strings:AppStrings.GenerateLabelOutputFolder}"
+                               FontAttributes="Bold" />
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                            <Entry Grid.Column="0"
+                                   Text="{Binding GenerationOutputDirectoryPath}"
+                                   Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderOutputFolder}"
+                                   ClearButtonVisibility="WhileEditing" />
+                            <Button Grid.Column="1"
+                                    Style="{DynamicResource BrowseButton}"
+                                    Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
+                                    Command="{Binding BrowseGenerationOutputDirectoryCommand}"
+                                    AutomationProperties.Name="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}"
+                                    ToolTipProperties.Text="{x:Static strings:AppStrings.GenerateBrowseOutputFolder}" />
+                        </Grid>
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="{x:Static strings:AppStrings.GenerateLabelPlanFileName}"
+                               FontAttributes="Bold" />
+                        <Entry Text="{Binding PlanFileName}"
+                               Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderPlanFileName}"
+                               ClearButtonVisibility="WhileEditing" />
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="{x:Static strings:AppStrings.GenerateLabelGeneratedPlanPath}"
+                               FontAttributes="Bold" />
+                        <Label Text="{Binding GeneratedPlanPathPreview}"
+                               FontSize="12"
+                               LineBreakMode="WordWrap"
+                               TextColor="{DynamicResource TextLink}" />
+                    </VerticalStackLayout>
                 </VerticalStackLayout>
 
                 <HorizontalStackLayout Spacing="10">

--- a/src/Renamer.UI/Views/GenerateWorkspaceView.xaml.cs
+++ b/src/Renamer.UI/Views/GenerateWorkspaceView.xaml.cs
@@ -1,9 +1,43 @@
+using Renamer.UI.Plans;
+
 namespace Renamer.UI.Views;
 
 public partial class GenerateWorkspaceView : ContentView
 {
+    private bool advancedExpanded;
+
     public GenerateWorkspaceView()
     {
         InitializeComponent();
+    }
+
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        if (BindingContext is IPlanViewModel vm)
+        {
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+            if (vm.HasAdvancedOverrides)
+                SetAdvancedExpanded(true);
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(IPlanViewModel.HasAdvancedOverrides) &&
+            sender is IPlanViewModel vm && vm.HasAdvancedOverrides)
+        {
+            SetAdvancedExpanded(true);
+        }
+    }
+
+    private void OnAdvancedToggleClicked(object? sender, EventArgs e) =>
+        SetAdvancedExpanded(!advancedExpanded);
+
+    private void SetAdvancedExpanded(bool expanded)
+    {
+        advancedExpanded = expanded;
+        AdvancedPanel.IsVisible = expanded;
+        AdvancedCollapsedHint.IsVisible = !expanded;
     }
 }


### PR DESCRIPTION
## Summary
- Output folder defaults to root path when user hasn't overridden it; subsequent root changes keep following until user manually sets a different output
- Plan filename defaults to `rename-plan.json` (sourced from `AppStrings.DefaultPlanFileName`)
- `HasAdvancedOverrides` on `IPlanViewModel` tracks whether either default has been overridden
- `GenerateWorkspaceView` wraps output folder / filename / path-preview in a collapsible `Advanced` disclosure, collapsed by default, auto-expands when overrides are active

## Test plan
- [x] `PlanViewModelDefaultsTests` — 10 new tests covering defaults, auto-fill, override preservation, and `HasAdvancedOverrides` change notifications
- [x] `dotnet test Renamer.sln` — 114 tests pass

## Notes
Apply workspace: `BrowsePlanCommand` picks a plan file (not a folder) so no default pattern applies there — no changes needed.

Closes #52
