### PR TITLE
refactor(ui): 370 plan items as cards

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -44,7 +44,7 @@
 - [x] 340 Thin rail redesign (`docs/specs/340-thin-rail-redesign.md`)
 - [x] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
 - [x] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
-- [ ] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)
+- [x] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)
 - [ ] 380 Stat strip and result banner (`docs/specs/380-stat-strip-and-result-banner.md`)
 - [ ] 390 Compact theme toggle (`docs/specs/390-compact-theme-toggle.md`)
 

--- a/src/Renamer.Tests/Plans/PlanOperationItemDisplayTests.cs
+++ b/src/Renamer.Tests/Plans/PlanOperationItemDisplayTests.cs
@@ -1,0 +1,69 @@
+using Renamer.UI.Plans;
+using Renamer.UI.Resources.Strings;
+
+namespace Renamer.Tests.Plans;
+
+public sealed class PlanOperationItemDisplayTests
+{
+    [Fact]
+    public void FromDisplay_ReturnsSouceName()
+    {
+        var item = MakeItem(sourceName: "Trip A");
+
+        Assert.Equal("Trip A", item.FromDisplay);
+    }
+
+    [Fact]
+    public void ToDisplay_ReturnsDestinationName()
+    {
+        var item = MakeItem(destinationName: "2024-06-12 - Trip A");
+
+        Assert.Equal("2024-06-12 - Trip A", item.ToDisplay);
+    }
+
+    [Fact]
+    public void StatusPillText_WhenNoWarnings_ReturnsOk()
+    {
+        var item = MakeItem(hasWarnings: false);
+
+        Assert.Equal(AppStrings.PlanOperationStatusOk, item.StatusPillText);
+    }
+
+    [Fact]
+    public void StatusPillText_WhenHasWarnings_ReturnsWarning()
+    {
+        var item = MakeItem(hasWarnings: true);
+
+        Assert.Equal(AppStrings.PlanOperationStatusWarning, item.StatusPillText);
+    }
+
+    [Fact]
+    public void StatusPillColor_WhenNoWarnings_IsGreen()
+    {
+        var item = MakeItem(hasWarnings: false);
+
+        Assert.Equal("#166534", item.StatusPillColor);
+    }
+
+    [Fact]
+    public void StatusPillColor_WhenHasWarnings_IsAmber()
+    {
+        var item = MakeItem(hasWarnings: true);
+
+        Assert.Equal("#B45309", item.StatusPillColor);
+    }
+
+    private static PlanOperationItem MakeItem(
+        string sourceName = "Trip A",
+        string destinationName = "2024-06-12 - Trip A",
+        bool hasWarnings = false) =>
+        new(
+            OpId: "test-op-id",
+            SourceName: sourceName,
+            DestinationName: destinationName,
+            SourcePath: "/photos/Trip A",
+            PlannedDestinationPath: "/photos/2024-06-12 - Trip A",
+            DateRangeText: "2024-06-12",
+            FileCountText: "5 files checked, 0 without photo dates",
+            HasWarnings: hasWarnings);
+}

--- a/src/Renamer.UI/Plans/PlanOperationItem.cs
+++ b/src/Renamer.UI/Plans/PlanOperationItem.cs
@@ -1,3 +1,5 @@
+using Renamer.UI.Resources.Strings;
+
 namespace Renamer.UI.Plans;
 
 public sealed record PlanOperationItem(
@@ -7,4 +9,11 @@ public sealed record PlanOperationItem(
     string SourcePath,
     string PlannedDestinationPath,
     string DateRangeText,
-    string FileCountText);
+    string FileCountText,
+    bool HasWarnings)
+{
+    public string FromDisplay => SourceName;
+    public string ToDisplay => DestinationName;
+    public string StatusPillText => HasWarnings ? AppStrings.PlanOperationStatusWarning : AppStrings.PlanOperationStatusOk;
+    public string StatusPillColor => HasWarnings ? "#B45309" : "#166534";
+}

--- a/src/Renamer.UI/Plans/PlanViewModel.cs
+++ b/src/Renamer.UI/Plans/PlanViewModel.cs
@@ -662,7 +662,8 @@ public sealed class PlanViewModel : IPlanViewModel
                     CultureInfo.InvariantCulture,
                     AppStrings.PreviewOperationFileCount,
                     operation.Reason.FilesConsidered,
-                    operation.Reason.FilesSkippedMissingExif)));
+                    operation.Reason.FilesSkippedMissingExif),
+                HasWarnings: operation.Reason.FilesSkippedMissingExif > 0));
         }
 
         SetState(PlanViewState.Loaded);

--- a/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
@@ -126,6 +126,10 @@ namespace Renamer.UI.Resources.Strings
         internal static string PreviewOperationsDescription => ResourceManager.GetString("PreviewOperationsDescription", resourceCulture)!;
         internal static string PreviewOperationFileCount => ResourceManager.GetString("PreviewOperationFileCount", resourceCulture)!;
 
+        internal static string PlanOperationStatusOk => ResourceManager.GetString("PlanOperationStatusOk", resourceCulture)!;
+
+        internal static string PlanOperationStatusWarning => ResourceManager.GetString("PlanOperationStatusWarning", resourceCulture)!;
+
         internal static string PreviewStatusDefault => ResourceManager.GetString("PreviewStatusDefault", resourceCulture)!;
         internal static string PreviewCreatedAtDefault => ResourceManager.GetString("PreviewCreatedAtDefault", resourceCulture)!;
         internal static string PreviewStatusPathUpdated => ResourceManager.GetString("PreviewStatusPathUpdated", resourceCulture)!;

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -421,6 +421,14 @@
     <value>{0} files checked, {1} without photo dates</value>
     <comment/>
   </data>
+  <data name="PlanOperationStatusOk" xml:space="preserve">
+    <value>OK</value>
+    <comment/>
+  </data>
+  <data name="PlanOperationStatusWarning" xml:space="preserve">
+    <value>Warning</value>
+    <comment/>
+  </data>
   <data name="PreviewStatusDefault" xml:space="preserve">
     <value>Choose a rename-plan.json file to review the proposed folder names.</value>
     <comment/>

--- a/src/Renamer.UI/Resources/Styles/Styles.xaml
+++ b/src/Renamer.UI/Resources/Styles/Styles.xaml
@@ -177,6 +177,15 @@
         <Setter Property="TextColor" Value="{DynamicResource TextPrimary}" />
     </Style>
 
+    <Style TargetType="Border" x:Key="PlanOperationCard">
+        <Setter Property="Background" Value="{DynamicResource BackgroundSecondary}" />
+        <Setter Property="Stroke" Value="{DynamicResource BorderPrimary}" />
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="StrokeShape" Value="RoundRectangle 8" />
+        <Setter Property="Padding" Value="14" />
+        <Setter Property="Margin" Value="0,0,0,8" />
+    </Style>
+
     <Style TargetType="Button" x:Key="BrowseButton">
         <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
         <Setter Property="TextColor" Value="{DynamicResource TextSecondary}" />

--- a/src/Renamer.UI/Views/PreviewWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/PreviewWorkspaceView.xaml
@@ -160,52 +160,37 @@
                                      BindableLayout.ItemsSource="{Binding Operations}">
                     <BindableLayout.ItemTemplate>
                         <DataTemplate x:DataType="model:PlanOperationItem">
-                            <Border Padding="14"
-                                    Margin="0,0,0,10">
-                                <VerticalStackLayout Spacing="10">
-                                    <Grid ColumnDefinitions="*,Auto"
-                                          ColumnSpacing="12">
-                                        <VerticalStackLayout Spacing="2">
-                                            <Label Text="{Binding SourceName}"
-                                                   FontSize="16"
-                                                   FontAttributes="Bold" />
-                                            <Label Text="{Binding SourcePath}"
-                                                   FontSize="12"
-                                                   LineBreakMode="WordWrap"
-                                                   TextColor="{DynamicResource TextMuted}" />
-                                        </VerticalStackLayout>
-
-                                        <Label Grid.Column="1"
-                                               Text="{Binding DateRangeText}"
+                            <Border Style="{DynamicResource PlanOperationCard}">
+                                <Grid ColumnDefinitions="*,Auto"
+                                      ColumnSpacing="12">
+                                    <VerticalStackLayout Grid.Column="0"
+                                                         Spacing="4">
+                                        <Label Text="{Binding FromDisplay}"
                                                FontSize="12"
-                                               HorizontalTextAlignment="End" />
-                                    </Grid>
-
-                                    <BoxView HeightRequest="1"
-                                             BackgroundColor="{DynamicResource DividerColor}" />
-
-                                    <VerticalStackLayout Spacing="2">
-                                        <Label Text="{Binding DestinationName}"
-                                               FontSize="16"
+                                               FontFamily="Courier New"
+                                               TextColor="{DynamicResource TextMuted}"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding ToDisplay}"
+                                               FontSize="14"
+                                               FontFamily="Courier New"
                                                FontAttributes="Bold"
-                                               TextColor="{DynamicResource TextLink}" />
-                                        <Label Text="{Binding PlannedDestinationPath}"
-                                               FontSize="12"
-                                               LineBreakMode="WordWrap"
-                                               TextColor="{DynamicResource TextMuted}" />
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding DateRangeText}"
+                                               FontSize="11"
+                                               TextColor="{DynamicResource TextSecondary}" />
                                     </VerticalStackLayout>
 
-                                    <Grid ColumnDefinitions="*,Auto"
-                                          ColumnSpacing="12">
-                                        <Label Text="{Binding FileCountText}"
-                                               FontSize="12" />
-                                        <Label Grid.Column="1"
-                                               Text="{Binding OpId}"
+                                    <Border Grid.Column="1"
+                                            Padding="8,4"
+                                            StrokeThickness="0"
+                                            StrokeShape="RoundRectangle 12"
+                                            BackgroundColor="{Binding StatusPillColor}"
+                                            VerticalOptions="Start">
+                                        <Label Text="{Binding StatusPillText}"
                                                FontSize="11"
-                                               HorizontalTextAlignment="End"
-                                               TextColor="{DynamicResource TextMuted}" />
-                                    </Grid>
-                                </VerticalStackLayout>
+                                               TextColor="#FFFFFF" />
+                                    </Border>
+                                </Grid>
                             </Border>
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>


### PR DESCRIPTION
## Summary
- Rewrites `PreviewWorkspaceView` operation `ItemTemplate` as bounded cards (`PlanOperationCard` style): original name (muted, monospace) above proposed name (bold, monospace), status pill on the right
- Adds `HasWarnings` to `PlanOperationItem` constructor (populated from `FilesSkippedMissingExif > 0`)
- Derived properties: `FromDisplay`, `ToDisplay`, `StatusPillText`, `StatusPillColor`
- Adds `PlanOperationCard` border style to `Styles.xaml`
- Adds `PlanOperationStatusOk` / `PlanOperationStatusWarning` string resources

## Notes
Monospace font uses `Courier New` which renders correctly on Windows. Cross-platform monospace font registration is deferred.

## Test plan
- [x] `PlanOperationItemDisplayTests` — 6 new tests covering pill text/color and from/to display for both warning states
- [x] `dotnet test Renamer.sln` — 120 tests pass

Closes #53
