### PR TITLE
refactor(ui): 380 stat strip and result banner

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -45,7 +45,7 @@
 - [x] 350 Inline browse buttons (`docs/specs/350-inline-browse-buttons.md`)
 - [x] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
 - [x] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)
-- [ ] 380 Stat strip and result banner (`docs/specs/380-stat-strip-and-result-banner.md`)
+- [x] 380 Stat strip and result banner (`docs/specs/380-stat-strip-and-result-banner.md`)
 - [ ] 390 Compact theme toggle (`docs/specs/390-compact-theme-toggle.md`)
 
 ## Validation

--- a/src/Renamer.Tests/UI/PlanViewModelSummaryTests.cs
+++ b/src/Renamer.Tests/UI/PlanViewModelSummaryTests.cs
@@ -1,0 +1,200 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Renamer.Core.Contracts;
+using Renamer.Core.Execution;
+using Renamer.Core.Planning;
+using Renamer.Core.Serialization;
+using Renamer.UI.Plans;
+using Renamer.UI.Resources.Strings;
+
+namespace Renamer.Tests.UI;
+
+public sealed class PlanViewModelSummaryTests
+{
+    [Fact]
+    public async Task PreviewStatChanges_AfterLoad_FormatsOperationCount()
+    {
+        var vm = MakeViewModel(operationCount: 2, warnings: 0);
+        vm.PlanPath = "/tmp/plan.json";
+
+        await vm.LoadAsync();
+
+        Assert.Equal("2 changes", vm.PreviewStatChanges);
+    }
+
+    [Fact]
+    public async Task PreviewStatNotes_WhenZero_UsesPlural()
+    {
+        var vm = MakeViewModel(operationCount: 1, warnings: 0);
+        vm.PlanPath = "/tmp/plan.json";
+
+        await vm.LoadAsync();
+
+        Assert.Equal(string.Format(AppStrings.PreviewStatNotesPluralFormat, 0), vm.PreviewStatNotes);
+    }
+
+    [Fact]
+    public async Task PreviewStatNotes_WhenOne_UsesSingular()
+    {
+        var vm = MakeViewModel(operationCount: 1, warnings: 1);
+        vm.PlanPath = "/tmp/plan.json";
+
+        await vm.LoadAsync();
+
+        Assert.Equal(string.Format(AppStrings.PreviewStatNotesSingularFormat, 1), vm.PreviewStatNotes);
+    }
+
+    [Fact]
+    public async Task PreviewStatNotes_WhenMany_UsesPlural()
+    {
+        var vm = MakeViewModel(operationCount: 1, warnings: 3);
+        vm.PlanPath = "/tmp/plan.json";
+
+        await vm.LoadAsync();
+
+        Assert.Equal(string.Format(AppStrings.PreviewStatNotesPluralFormat, 3), vm.PreviewStatNotes);
+    }
+
+    [Fact]
+    public async Task ApplyResultHeadline_WhenOne_UsesSingular()
+    {
+        var vm = MakeViewModelForApply(success: 1, skipped: 0, failed: 0);
+        vm.PlanPath = "/tmp/plan.json";
+        await vm.LoadAsync();
+
+        await vm.ApplyAsync();
+
+        Assert.Equal(string.Format(AppStrings.ApplyResultHeadlineSingular, 1), vm.ApplyResultHeadline);
+    }
+
+    [Fact]
+    public async Task ApplyResultHeadline_WhenMany_UsesPlural()
+    {
+        var vm = MakeViewModelForApply(success: 3, skipped: 0, failed: 0);
+        vm.PlanPath = "/tmp/plan.json";
+        await vm.LoadAsync();
+
+        await vm.ApplyAsync();
+
+        Assert.Equal(string.Format(AppStrings.ApplyResultHeadlinePlural, 3), vm.ApplyResultHeadline);
+    }
+
+    [Fact]
+    public async Task ApplyResultHeadline_WhenZero_UsesPlural()
+    {
+        var vm = MakeViewModelForApply(success: 0, skipped: 1, failed: 1);
+        vm.PlanPath = "/tmp/plan.json";
+        await vm.LoadAsync();
+
+        await vm.ApplyAsync();
+
+        Assert.Equal(string.Format(AppStrings.ApplyResultHeadlinePlural, 0), vm.ApplyResultHeadline);
+    }
+
+    [Fact]
+    public async Task ApplyResultBreakdown_FormatsSkippedAndFailed()
+    {
+        var vm = MakeViewModelForApply(success: 2, skipped: 1, failed: 3);
+        vm.PlanPath = "/tmp/plan.json";
+        await vm.LoadAsync();
+
+        await vm.ApplyAsync();
+
+        Assert.Equal(string.Format(AppStrings.ApplyResultBreakdownFormat, 1, 3), vm.ApplyResultBreakdown);
+    }
+
+    private static PlanViewModel MakeViewModel(int operationCount, int warnings) =>
+        new(
+            new FakePlanBuilder(),
+            new FakePlanSerializer(CreatePlan(operationCount, warnings)),
+            new FakePlanFilePicker(),
+            new FakeFolderPathPicker(),
+            new FakeRootPathOpener(),
+            new FakeApplyEngine(CreateReport(0, 0, 0)),
+            NullLogger<PlanViewModel>.Instance);
+
+    private static PlanViewModel MakeViewModelForApply(int success, int skipped, int failed) =>
+        new(
+            new FakePlanBuilder(),
+            new FakePlanSerializer(CreatePlan(1, 0)),
+            new FakePlanFilePicker(),
+            new FakeFolderPathPicker(),
+            new FakeRootPathOpener(),
+            new FakeApplyEngine(CreateReport(success, skipped, failed)),
+            NullLogger<PlanViewModel>.Instance);
+
+    private static RenamePlan CreatePlan(int operationCount, int warnings) =>
+        new()
+        {
+            SchemaVersion = "1.0",
+            PlanId = "test-id",
+            CreatedAtUtc = "2026-01-01T00:00:00Z",
+            RootPath = "/photos",
+            Operations = Enumerable.Range(0, operationCount)
+                .Select(i => new RenamePlanOperation
+                {
+                    OpId = $"op-{i}",
+                    SourcePath = $"/photos/folder-{i}",
+                    PlannedDestinationPath = $"/photos/2024-01-01 - folder-{i}",
+                    Reason = new RenamePlanReason
+                    {
+                        StartDate = "2024-01-01",
+                        EndDate = "2024-01-01",
+                        FilesConsidered = 5,
+                        FilesSkippedMissingExif = i < warnings ? 1 : 0
+                    }
+                }).ToList(),
+            Summary = new RenamePlanSummary { OperationCount = operationCount, Warnings = warnings }
+        };
+
+    private static RenameReport CreateReport(int success, int skipped, int failed) =>
+        new()
+        {
+            SchemaVersion = "1.0",
+            PlanId = "test-id",
+            Outcome = "completed",
+            StartedAtUtc = "2026-01-01T00:00:00Z",
+            FinishedAtUtc = "2026-01-01T00:00:01Z",
+            Results = [],
+            Summary = new RenameReportSummary
+            {
+                Success = success,
+                Skipped = skipped,
+                Failed = failed,
+                Drifted = 0
+            }
+        };
+
+    private sealed class FakePlanBuilder : IPlanBuilder
+    {
+        public RenamePlan Build(string rootPath) => throw new NotImplementedException();
+    }
+
+    private sealed class FakePlanSerializer(RenamePlan plan) : IPlanSerializer
+    {
+        public RenamePlan Read(string inputPath) => plan;
+        public void Write(string outputPath, RenamePlan plan) => throw new NotImplementedException();
+    }
+
+    private sealed class FakePlanFilePicker : IPlanFilePicker
+    {
+        public Task<string?> PickPlanPathAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private sealed class FakeFolderPathPicker : IFolderPathPicker
+    {
+        public Task<string?> PickFolderPathAsync(string title, CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private sealed class FakeRootPathOpener : IRootPathOpener
+    {
+        public Task OpenAsync(string directoryPath, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class FakeApplyEngine(RenameReport report) : IApplyEngine
+    {
+        public RenameReport Execute(RenamePlan plan) => report;
+    }
+}

--- a/src/Renamer.UI/Plans/IPlanViewModel.cs
+++ b/src/Renamer.UI/Plans/IPlanViewModel.cs
@@ -41,6 +41,14 @@ public interface IPlanViewModel : INotifyPropertyChanged
 
     bool HasAdvancedOverrides { get; }
 
+    string PreviewStatChanges { get; }
+
+    string PreviewStatNotes { get; }
+
+    string ApplyResultHeadline { get; }
+
+    string ApplyResultBreakdown { get; }
+
     string PlanPath { get; set; }
 
     string StatusMessage { get; }

--- a/src/Renamer.UI/Plans/PlanViewModel.cs
+++ b/src/Renamer.UI/Plans/PlanViewModel.cs
@@ -58,6 +58,11 @@ public sealed class PlanViewModel : IPlanViewModel
     private bool isAutoUpdatingGenerationOutputDirectory;
     private string? autoFilledGenerationOutputDirectoryPath;
     private bool planFileNameOverridden;
+    private int operationCount;
+    private int warningCount;
+    private int applySuccessCount;
+    private int applyFailedCount;
+    private int applySkippedCount;
 
     public PlanViewModel(
         IPlanBuilder planBuilder,
@@ -210,6 +215,22 @@ public sealed class PlanViewModel : IPlanViewModel
     public bool HasAdvancedOverrides =>
         (autoFilledGenerationOutputDirectoryPath == null && !string.IsNullOrWhiteSpace(generationOutputDirectoryPath)) ||
         planFileNameOverridden;
+
+    public string PreviewStatChanges =>
+        string.Format(CultureInfo.InvariantCulture, AppStrings.PreviewStatChangesFormat, operationCount);
+
+    public string PreviewStatNotes =>
+        string.Format(CultureInfo.InvariantCulture,
+            warningCount == 1 ? AppStrings.PreviewStatNotesSingularFormat : AppStrings.PreviewStatNotesPluralFormat,
+            warningCount);
+
+    public string ApplyResultHeadline =>
+        string.Format(CultureInfo.InvariantCulture,
+            applySuccessCount == 1 ? AppStrings.ApplyResultHeadlineSingular : AppStrings.ApplyResultHeadlinePlural,
+            applySuccessCount);
+
+    public string ApplyResultBreakdown =>
+        string.Format(CultureInfo.InvariantCulture, AppStrings.ApplyResultBreakdownFormat, applySkippedCount, applyFailedCount);
 
     public string PlanPath
     {
@@ -646,8 +667,12 @@ public sealed class PlanViewModel : IPlanViewModel
     {
         RootPath = plan.RootPath;
         CreatedAtDisplay = FormatTimestamp(plan.CreatedAtUtc);
-        OperationCountText = plan.Summary.OperationCount.ToString(CultureInfo.InvariantCulture);
-        WarningCountText = plan.Summary.Warnings.ToString(CultureInfo.InvariantCulture);
+        operationCount = plan.Summary.OperationCount;
+        warningCount = plan.Summary.Warnings;
+        OperationCountText = operationCount.ToString(CultureInfo.InvariantCulture);
+        WarningCountText = warningCount.ToString(CultureInfo.InvariantCulture);
+        OnPropertyChanged(nameof(PreviewStatChanges));
+        OnPropertyChanged(nameof(PreviewStatNotes));
 
         foreach (var operation in plan.Operations)
         {
@@ -677,10 +702,15 @@ public sealed class PlanViewModel : IPlanViewModel
         ApplyOutcomeText = report.Outcome;
         ApplyStartedAtDisplay = FormatTimestamp(report.StartedAtUtc);
         ApplyFinishedAtDisplay = FormatTimestamp(report.FinishedAtUtc);
-        ApplySuccessCountText = report.Summary.Success.ToString(CultureInfo.InvariantCulture);
-        ApplyFailedCountText = report.Summary.Failed.ToString(CultureInfo.InvariantCulture);
-        ApplySkippedCountText = report.Summary.Skipped.ToString(CultureInfo.InvariantCulture);
+        applySuccessCount = report.Summary.Success;
+        applyFailedCount = report.Summary.Failed;
+        applySkippedCount = report.Summary.Skipped;
+        ApplySuccessCountText = applySuccessCount.ToString(CultureInfo.InvariantCulture);
+        ApplyFailedCountText = applyFailedCount.ToString(CultureInfo.InvariantCulture);
+        ApplySkippedCountText = applySkippedCount.ToString(CultureInfo.InvariantCulture);
         ApplyDriftedCountText = report.Summary.Drifted.ToString(CultureInfo.InvariantCulture);
+        OnPropertyChanged(nameof(ApplyResultHeadline));
+        OnPropertyChanged(nameof(ApplyResultBreakdown));
 
         foreach (var result in report.Results)
         {
@@ -715,8 +745,12 @@ public sealed class PlanViewModel : IPlanViewModel
     {
         RootPath = string.Empty;
         CreatedAtDisplay = AppStrings.PreviewCreatedAtDefault;
+        operationCount = 0;
+        warningCount = 0;
         OperationCountText = "0";
         WarningCountText = "0";
+        OnPropertyChanged(nameof(PreviewStatChanges));
+        OnPropertyChanged(nameof(PreviewStatNotes));
     }
 
     private void ResetPlanPreviewState()
@@ -750,10 +784,15 @@ public sealed class PlanViewModel : IPlanViewModel
         ApplyOutcomeText = AppStrings.ApplyStatusOutcomeDefault;
         ApplyStartedAtDisplay = AppStrings.ApplyStatusStartedDefault;
         ApplyFinishedAtDisplay = AppStrings.ApplyStatusFinishedDefault;
+        applySuccessCount = 0;
+        applyFailedCount = 0;
+        applySkippedCount = 0;
         ApplySuccessCountText = "0";
         ApplyFailedCountText = "0";
         ApplySkippedCountText = "0";
         ApplyDriftedCountText = "0";
+        OnPropertyChanged(nameof(ApplyResultHeadline));
+        OnPropertyChanged(nameof(ApplyResultBreakdown));
     }
 
     private void SetApplyError(string title, string message)

--- a/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
@@ -116,6 +116,13 @@ namespace Renamer.UI.Resources.Strings
         internal static string PreviewLoadingLabel => ResourceManager.GetString("PreviewLoadingLabel", resourceCulture)!;
         internal static string PreviewErrorHeading => ResourceManager.GetString("PreviewErrorHeading", resourceCulture)!;
         internal static string PreviewSummarySectionHeader => ResourceManager.GetString("PreviewSummarySectionHeader", resourceCulture)!;
+        internal static string PreviewStatChangesFormat => ResourceManager.GetString("PreviewStatChangesFormat", resourceCulture)!;
+        internal static string PreviewStatNotesSingularFormat => ResourceManager.GetString("PreviewStatNotesSingularFormat", resourceCulture)!;
+        internal static string PreviewStatNotesPluralFormat => ResourceManager.GetString("PreviewStatNotesPluralFormat", resourceCulture)!;
+        internal static string ApplyResultHeadlineSingular => ResourceManager.GetString("ApplyResultHeadlineSingular", resourceCulture)!;
+        internal static string ApplyResultHeadlinePlural => ResourceManager.GetString("ApplyResultHeadlinePlural", resourceCulture)!;
+        internal static string ApplyResultBreakdownFormat => ResourceManager.GetString("ApplyResultBreakdownFormat", resourceCulture)!;
+        internal static string ApplyResultDetailsLabel => ResourceManager.GetString("ApplyResultDetailsLabel", resourceCulture)!;
         internal static string PreviewSummaryDescription => ResourceManager.GetString("PreviewSummaryDescription", resourceCulture)!;
         internal static string PreviewFieldRootPath => ResourceManager.GetString("PreviewFieldRootPath", resourceCulture)!;
         internal static string PreviewFieldCreatedAt => ResourceManager.GetString("PreviewFieldCreatedAt", resourceCulture)!;

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -385,6 +385,34 @@
     <value>Before you rename</value>
     <comment/>
   </data>
+  <data name="PreviewStatChangesFormat" xml:space="preserve">
+    <value>{0} changes</value>
+    <comment/>
+  </data>
+  <data name="PreviewStatNotesSingularFormat" xml:space="preserve">
+    <value>{0} note</value>
+    <comment/>
+  </data>
+  <data name="PreviewStatNotesPluralFormat" xml:space="preserve">
+    <value>{0} notes</value>
+    <comment/>
+  </data>
+  <data name="ApplyResultHeadlineSingular" xml:space="preserve">
+    <value>Renamed {0} folder</value>
+    <comment/>
+  </data>
+  <data name="ApplyResultHeadlinePlural" xml:space="preserve">
+    <value>Renamed {0} folders</value>
+    <comment/>
+  </data>
+  <data name="ApplyResultBreakdownFormat" xml:space="preserve">
+    <value>{0} skipped · {1} failed</value>
+    <comment/>
+  </data>
+  <data name="ApplyResultDetailsLabel" xml:space="preserve">
+    <value>Details</value>
+    <comment/>
+  </data>
   <data name="PreviewSummaryDescription" xml:space="preserve">
     <value>Check where the plan came from, when it was created, and how many folder names it will change.</value>
     <comment/>

--- a/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
@@ -92,68 +92,72 @@
         </Border>
 
         <Border Padding="16">
-            <VerticalStackLayout Spacing="14">
-                <Label Text="{x:Static strings:AppStrings.ApplySummarySectionHeader}"
-                       FontSize="18"
+            <VerticalStackLayout Spacing="8">
+                <Label Text="{Binding ApplyResultHeadline}"
+                       FontSize="22"
                        FontAttributes="Bold" />
-
-                <Grid ColumnDefinitions="*,*"
-                      ColumnSpacing="16">
-                    <VerticalStackLayout Grid.Column="0"
-                                         Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.ApplyFieldOutcome}"
-                               FontAttributes="Bold" />
-                        <Label Text="{Binding ApplyOutcomeText}" />
-                    </VerticalStackLayout>
-
-                    <VerticalStackLayout Grid.Column="1"
-                                         Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.ApplyFieldDrifted}"
-                               FontAttributes="Bold" />
-                        <Label Text="{Binding ApplyDriftedCountText}" />
-                    </VerticalStackLayout>
-                </Grid>
-
-                <Grid ColumnDefinitions="*,*"
-                      ColumnSpacing="16">
-                    <VerticalStackLayout Grid.Column="0"
-                                         Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.ApplyFieldStarted}"
-                               FontAttributes="Bold" />
-                        <Label Text="{Binding ApplyStartedAtDisplay}" />
-                    </VerticalStackLayout>
-
-                    <VerticalStackLayout Grid.Column="1"
-                                         Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.ApplyFieldFinished}"
-                               FontAttributes="Bold" />
-                        <Label Text="{Binding ApplyFinishedAtDisplay}" />
-                    </VerticalStackLayout>
-                </Grid>
-
-                <Grid ColumnDefinitions="*,*,*"
-                      ColumnSpacing="16">
-                    <VerticalStackLayout Grid.Column="0"
-                                         Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.ApplyFieldSuccess}"
-                               FontAttributes="Bold" />
-                        <Label Text="{Binding ApplySuccessCountText}" />
-                    </VerticalStackLayout>
-
-                    <VerticalStackLayout Grid.Column="1"
-                                         Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.ApplyFieldSkipped}"
-                               FontAttributes="Bold" />
-                        <Label Text="{Binding ApplySkippedCountText}" />
-                    </VerticalStackLayout>
-
-                    <VerticalStackLayout Grid.Column="2"
-                                         Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.ApplyFieldFailed}"
-                               FontAttributes="Bold" />
-                        <Label Text="{Binding ApplyFailedCountText}" />
-                    </VerticalStackLayout>
-                </Grid>
+                <Label Text="{Binding ApplyResultBreakdown}"
+                       FontSize="13"
+                       TextColor="{DynamicResource TextSecondary}" />
+                <Button x:Name="DetailsToggle"
+                        Text="{x:Static strings:AppStrings.ApplyResultDetailsLabel}"
+                        Clicked="OnDetailsToggleClicked"
+                        HorizontalOptions="Start" />
+                <VerticalStackLayout x:Name="DetailsPanel"
+                                     Spacing="14"
+                                     IsVisible="False">
+                    <Grid ColumnDefinitions="*,*"
+                          ColumnSpacing="16">
+                        <VerticalStackLayout Grid.Column="0"
+                                             Spacing="4">
+                            <Label Text="{x:Static strings:AppStrings.ApplyFieldOutcome}"
+                                   FontAttributes="Bold" />
+                            <Label Text="{Binding ApplyOutcomeText}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1"
+                                             Spacing="4">
+                            <Label Text="{x:Static strings:AppStrings.ApplyFieldDrifted}"
+                                   FontAttributes="Bold" />
+                            <Label Text="{Binding ApplyDriftedCountText}" />
+                        </VerticalStackLayout>
+                    </Grid>
+                    <Grid ColumnDefinitions="*,*"
+                          ColumnSpacing="16">
+                        <VerticalStackLayout Grid.Column="0"
+                                             Spacing="4">
+                            <Label Text="{x:Static strings:AppStrings.ApplyFieldStarted}"
+                                   FontAttributes="Bold" />
+                            <Label Text="{Binding ApplyStartedAtDisplay}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1"
+                                             Spacing="4">
+                            <Label Text="{x:Static strings:AppStrings.ApplyFieldFinished}"
+                                   FontAttributes="Bold" />
+                            <Label Text="{Binding ApplyFinishedAtDisplay}" />
+                        </VerticalStackLayout>
+                    </Grid>
+                    <Grid ColumnDefinitions="*,*,*"
+                          ColumnSpacing="16">
+                        <VerticalStackLayout Grid.Column="0"
+                                             Spacing="4">
+                            <Label Text="{x:Static strings:AppStrings.ApplyFieldSuccess}"
+                                   FontAttributes="Bold" />
+                            <Label Text="{Binding ApplySuccessCountText}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1"
+                                             Spacing="4">
+                            <Label Text="{x:Static strings:AppStrings.ApplyFieldSkipped}"
+                                   FontAttributes="Bold" />
+                            <Label Text="{Binding ApplySkippedCountText}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="2"
+                                             Spacing="4">
+                            <Label Text="{x:Static strings:AppStrings.ApplyFieldFailed}"
+                                   FontAttributes="Bold" />
+                            <Label Text="{Binding ApplyFailedCountText}" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </VerticalStackLayout>
             </VerticalStackLayout>
         </Border>
 

--- a/src/Renamer.UI/Views/ApplyWorkspaceView.xaml.cs
+++ b/src/Renamer.UI/Views/ApplyWorkspaceView.xaml.cs
@@ -2,8 +2,16 @@ namespace Renamer.UI.Views;
 
 public partial class ApplyWorkspaceView : ContentView
 {
+    private bool detailsExpanded;
+
     public ApplyWorkspaceView()
     {
         InitializeComponent();
+    }
+
+    private void OnDetailsToggleClicked(object? sender, EventArgs e)
+    {
+        detailsExpanded = !detailsExpanded;
+        DetailsPanel.IsVisible = detailsExpanded;
     }
 }

--- a/src/Renamer.UI/Views/PreviewWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/PreviewWorkspaceView.xaml
@@ -81,15 +81,7 @@
         <VerticalStackLayout Spacing="18"
                              IsVisible="{Binding IsLoaded}">
             <Border Padding="16">
-                <VerticalStackLayout Spacing="16">
-                    <VerticalStackLayout Spacing="4">
-                        <Label Text="{x:Static strings:AppStrings.PreviewSummarySectionHeader}"
-                               FontSize="18"
-                               FontAttributes="Bold" />
-                        <Label Text="{x:Static strings:AppStrings.PreviewSummaryDescription}"
-                               FontSize="13" />
-                    </VerticalStackLayout>
-
+                <VerticalStackLayout Spacing="12">
                     <Border Padding="14"
                             Background="{DynamicResource BackgroundTertiary}">
                         <VerticalStackLayout Spacing="6">
@@ -105,36 +97,21 @@
                         </VerticalStackLayout>
                     </Border>
 
-                    <Grid ColumnDefinitions="*,*,*"
-                          ColumnSpacing="16">
+                    <Grid ColumnDefinitions="*,*"
+                          ColumnSpacing="12">
                         <Border Grid.Column="0"
                                 Padding="14"
                                 Background="{DynamicResource BackgroundTertiary}">
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{x:Static strings:AppStrings.PreviewFieldCreatedAt}"
-                                       FontAttributes="Bold" />
-                                <Label Text="{Binding CreatedAtDisplay}" />
-                            </VerticalStackLayout>
+                            <Label Text="{Binding PreviewStatChanges}"
+                                   FontSize="16"
+                                   FontAttributes="Bold" />
                         </Border>
-
                         <Border Grid.Column="1"
                                 Padding="14"
                                 Background="{DynamicResource BackgroundTertiary}">
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{x:Static strings:AppStrings.PreviewFieldOperations}"
-                                       FontAttributes="Bold" />
-                                <Label Text="{Binding OperationCountText}" />
-                            </VerticalStackLayout>
-                        </Border>
-
-                        <Border Grid.Column="2"
-                                Padding="14"
-                                Background="{DynamicResource BackgroundTertiary}">
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{x:Static strings:AppStrings.PreviewFieldWarnings}"
-                                       FontAttributes="Bold" />
-                                <Label Text="{Binding WarningCountText}" />
-                            </VerticalStackLayout>
+                            <Label Text="{Binding PreviewStatNotes}"
+                                   FontSize="16"
+                                   FontAttributes="Bold" />
                         </Border>
                     </Grid>
                 </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- **Preview**: three-card "Before you rename" grid → two-tile stat strip (`PreviewStatChanges` / `PreviewStatNotes`) with singular/plural formatting
- **Apply**: verbose detail grid → headline ("Renamed N folders") + one-line breakdown ("N skipped · N failed"); full detail grids tucked behind a `Details ▾` disclosure (collapsed by default)
- Adds `PreviewStatChanges`, `PreviewStatNotes`, `ApplyResultHeadline`, `ApplyResultBreakdown` to `IPlanViewModel`

## Pluralization approach
Dual resource keys (`...Singular` / `...Plural`) — simpler than a runtime helper and keeps all copy in `AppStrings.resx`.

## Test plan
- [x] `PlanViewModelSummaryTests` — 8 new tests: stat formatting (0/1/many), headline singular/plural, breakdown
- [x] `dotnet test Renamer.sln` — 128 tests pass

Closes #54
