### PR TITLE
refactor(ui): 390 compact theme toggle

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -46,7 +46,7 @@
 - [x] 360 Plan file smart defaults (`docs/specs/360-plan-file-smart-defaults.md`)
 - [x] 370 Plan items as cards (`docs/specs/370-plan-items-as-cards.md`)
 - [x] 380 Stat strip and result banner (`docs/specs/380-stat-strip-and-result-banner.md`)
-- [ ] 390 Compact theme toggle (`docs/specs/390-compact-theme-toggle.md`)
+- [x] 390 Compact theme toggle (`docs/specs/390-compact-theme-toggle.md`)
 
 ## Validation
 - [ ] Windows smoke test

--- a/src/Renamer.Tests/Renamer.Tests.csproj
+++ b/src/Renamer.Tests/Renamer.Tests.csproj
@@ -47,6 +47,8 @@
     <Compile Include="..\Renamer.UI\Plans\PlanViewModel.cs" Link="UI\Plans\PlanViewModel.cs" />
     <Compile Include="..\Renamer.UI\Plans\PlanViewState.cs" Link="UI\Plans\PlanViewState.cs" />
     <Compile Include="..\Renamer.UI\UiLogPathProvider.cs" Link="UI\UiLogPathProvider.cs" />
+    <Compile Include="..\Renamer.UI\Services\ThemeMode.cs" Link="UI\Services\ThemeMode.cs" />
+    <Compile Include="..\Renamer.UI\Services\ThemeCycler.cs" Link="UI\Services\ThemeCycler.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Renamer.Tests/UI/ThemeServiceTests.cs
+++ b/src/Renamer.Tests/UI/ThemeServiceTests.cs
@@ -1,0 +1,29 @@
+using Renamer.UI.Services;
+
+namespace Renamer.Tests.UI;
+
+public sealed class ThemeServiceTests
+{
+    [Fact]
+    public void NextMode_FromLight_ReturnsDark() =>
+        Assert.Equal(ThemeMode.Dark, ThemeCycler.NextMode(ThemeMode.Light));
+
+    [Fact]
+    public void NextMode_FromDark_ReturnsSystem() =>
+        Assert.Equal(ThemeMode.System, ThemeCycler.NextMode(ThemeMode.Dark));
+
+    [Fact]
+    public void NextMode_FromSystem_ReturnsLight() =>
+        Assert.Equal(ThemeMode.Light, ThemeCycler.NextMode(ThemeMode.System));
+
+    [Fact]
+    public void NextMode_CyclesFullRound()
+    {
+        var mode = ThemeMode.Light;
+        mode = ThemeCycler.NextMode(mode);
+        mode = ThemeCycler.NextMode(mode);
+        mode = ThemeCycler.NextMode(mode);
+
+        Assert.Equal(ThemeMode.Light, mode);
+    }
+}

--- a/src/Renamer.UI/MainPage.xaml
+++ b/src/Renamer.UI/MainPage.xaml
@@ -33,25 +33,18 @@
             </VerticalStackLayout>
 
             <Border Grid.Column="1"
+                    x:Name="ThemePill"
                     Padding="12,8"
                     VerticalOptions="Center"
                     StrokeShape="RoundRectangle 8"
                     Stroke="{DynamicResource BorderPrimary}"
                     Background="{DynamicResource BackgroundTertiary}">
-                <HorizontalStackLayout Spacing="2">
-                    <RadioButton x:Name="LightRadio"
-                                 Content="Light"
-                                 GroupName="AppTheme"
-                                 CheckedChanged="OnThemeRadioChanged" />
-                    <RadioButton x:Name="DarkRadio"
-                                 Content="Dark"
-                                 GroupName="AppTheme"
-                                 CheckedChanged="OnThemeRadioChanged" />
-                    <RadioButton x:Name="SystemRadio"
-                                 Content="System"
-                                 GroupName="AppTheme"
-                                 CheckedChanged="OnThemeRadioChanged" />
-                </HorizontalStackLayout>
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnThemePillTapped" />
+                </Border.GestureRecognizers>
+                <Label x:Name="ThemePillLabel"
+                       FontSize="13"
+                       VerticalOptions="Center" />
             </Border>
         </Grid>
 

--- a/src/Renamer.UI/MainPage.xaml.cs
+++ b/src/Renamer.UI/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 using Renamer.UI.Plans;
+using Renamer.UI.Resources.Strings;
 using Renamer.UI.Services;
 
 namespace Renamer.UI;
@@ -6,7 +7,6 @@ namespace Renamer.UI;
 public partial class MainPage : ContentPage
 {
     private readonly ThemeService themeService;
-    private bool updatingTheme;
 
     public MainPage(IPlanViewModel viewModel, ThemeService themeService)
     {
@@ -16,38 +16,34 @@ public partial class MainPage : ContentPage
         themeService.ThemeModeChanged += OnThemeModeChanged;
     }
 
-    // Fired by ThemeService whenever the mode changes (including on first initialisation)
     private void OnThemeModeChanged(object? sender, ThemeMode mode) =>
         MainThread.BeginInvokeOnMainThread(() => ApplyModeToUi(mode));
 
     private void ApplyModeToUi(ThemeMode mode)
     {
         UpdateMenuCheckmarks(mode);
-        UpdateRadioButtons(mode);
+        UpdateThemePill(mode);
     }
 
-    // ── Radio buttons ────────────────────────────────────────────────────────
+    // ── Theme pill ───────────────────────────────────────────────────────────
 
-    private void UpdateRadioButtons(ThemeMode mode)
+    private void OnThemePillTapped(object? sender, TappedEventArgs e) =>
+        themeService.CycleTheme();
+
+    private void UpdateThemePill(ThemeMode mode)
     {
-        updatingTheme = true;
-        LightRadio.IsChecked  = mode == ThemeMode.Light;
-        DarkRadio.IsChecked   = mode == ThemeMode.Dark;
-        SystemRadio.IsChecked = mode == ThemeMode.System;
-        updatingTheme = false;
-    }
-
-    private void OnThemeRadioChanged(object? sender, CheckedChangedEventArgs e)
-    {
-        if (updatingTheme || !e.Value) return;
-
-        var mode = sender switch
+        var (glyph, label) = mode switch
         {
-            RadioButton r when ReferenceEquals(r, LightRadio)  => ThemeMode.Light,
-            RadioButton r when ReferenceEquals(r, DarkRadio)   => ThemeMode.Dark,
-            _                                                   => ThemeMode.System
+            ThemeMode.Light  => ("☀", AppStrings.ThemeToggleLight),
+            ThemeMode.Dark   => ("☾", AppStrings.ThemeToggleDark),
+            _                => ("⚙", AppStrings.ThemeToggleSystem)
         };
-        themeService.SetTheme(mode);
+
+        ThemePillLabel.Text = $"{glyph} {label}";
+
+        var accessibilityName = string.Format(AppStrings.ThemeToggleAccessibilityFormat, label);
+        AutomationProperties.SetName(ThemePill, accessibilityName);
+        ToolTipProperties.SetText(ThemePill, accessibilityName);
     }
 
     // ── Menu bar items ───────────────────────────────────────────────────────

--- a/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
@@ -123,6 +123,10 @@ namespace Renamer.UI.Resources.Strings
         internal static string ApplyResultHeadlinePlural => ResourceManager.GetString("ApplyResultHeadlinePlural", resourceCulture)!;
         internal static string ApplyResultBreakdownFormat => ResourceManager.GetString("ApplyResultBreakdownFormat", resourceCulture)!;
         internal static string ApplyResultDetailsLabel => ResourceManager.GetString("ApplyResultDetailsLabel", resourceCulture)!;
+        internal static string ThemeToggleLight => ResourceManager.GetString("ThemeToggleLight", resourceCulture)!;
+        internal static string ThemeToggleDark => ResourceManager.GetString("ThemeToggleDark", resourceCulture)!;
+        internal static string ThemeToggleSystem => ResourceManager.GetString("ThemeToggleSystem", resourceCulture)!;
+        internal static string ThemeToggleAccessibilityFormat => ResourceManager.GetString("ThemeToggleAccessibilityFormat", resourceCulture)!;
         internal static string PreviewSummaryDescription => ResourceManager.GetString("PreviewSummaryDescription", resourceCulture)!;
         internal static string PreviewFieldRootPath => ResourceManager.GetString("PreviewFieldRootPath", resourceCulture)!;
         internal static string PreviewFieldCreatedAt => ResourceManager.GetString("PreviewFieldCreatedAt", resourceCulture)!;

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -413,6 +413,22 @@
     <value>Details</value>
     <comment/>
   </data>
+  <data name="ThemeToggleLight" xml:space="preserve">
+    <value>Light</value>
+    <comment/>
+  </data>
+  <data name="ThemeToggleDark" xml:space="preserve">
+    <value>Dark</value>
+    <comment/>
+  </data>
+  <data name="ThemeToggleSystem" xml:space="preserve">
+    <value>System</value>
+    <comment/>
+  </data>
+  <data name="ThemeToggleAccessibilityFormat" xml:space="preserve">
+    <value>Theme: {0}</value>
+    <comment/>
+  </data>
   <data name="PreviewSummaryDescription" xml:space="preserve">
     <value>Check where the plan came from, when it was created, and how many folder names it will change.</value>
     <comment/>

--- a/src/Renamer.UI/Services/ThemeCycler.cs
+++ b/src/Renamer.UI/Services/ThemeCycler.cs
@@ -1,0 +1,11 @@
+namespace Renamer.UI.Services;
+
+public static class ThemeCycler
+{
+    public static ThemeMode NextMode(ThemeMode current) => current switch
+    {
+        ThemeMode.Light => ThemeMode.Dark,
+        ThemeMode.Dark  => ThemeMode.System,
+        _               => ThemeMode.Light
+    };
+}

--- a/src/Renamer.UI/Services/ThemeMode.cs
+++ b/src/Renamer.UI/Services/ThemeMode.cs
@@ -1,0 +1,3 @@
+namespace Renamer.UI.Services;
+
+public enum ThemeMode { System, Light, Dark }

--- a/src/Renamer.UI/Services/ThemeService.cs
+++ b/src/Renamer.UI/Services/ThemeService.cs
@@ -2,8 +2,6 @@ using Renamer.UI.Resources.Themes;
 
 namespace Renamer.UI.Services;
 
-public enum ThemeMode { System, Light, Dark }
-
 public sealed class ThemeService
 {
     private const string PreferenceKey = "AppThemeOverride";
@@ -31,6 +29,8 @@ public sealed class ThemeService
 
         Application.Current!.RequestedThemeChanged += OnOsThemeChanged;
     }
+
+    public void CycleTheme() => SetTheme(ThemeCycler.NextMode(CurrentMode));
 
     public void SetTheme(ThemeMode mode)
     {


### PR DESCRIPTION
## Summary
- Replaces the three-`RadioButton` Light/Dark/System group in the page header with a single tappable pill (☀ Light / ☾ Dark / ⚙ System)
- Tap cycles Light → Dark → System → Light via `ThemeCycler.NextMode`
- `AutomationProperties.Name` and `ToolTipProperties.Text` set to `"Theme: <mode>"` from `AppStrings.ThemeToggleAccessibilityFormat`
- View menu bar entries (`OnLightThemeClicked` etc.) unchanged
- Extracts `ThemeMode` enum and `ThemeCycler` static class into their own files so cycling logic is testable without MAUI dependencies

## Test plan
- [x] `ThemeServiceTests` — 4 tests: Light→Dark, Dark→System, System→Light, full cycle round-trip
- [x] `dotnet test Renamer.sln` — 132 tests pass

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)