### PR TITLE
refactor(ui): 410 compact shell and workspace frame

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -50,7 +50,7 @@
 
 ## UI reconciliation v3 (one PR per item)
 - [x] 400 UI reconciliation spec (`docs/specs/400-ui-reconciliation-spec.md`)
-- [ ] 410 Compact shell and workspace frame (`docs/specs/410-compact-shell-workspace-frame.md`)
+- [x] 410 Compact shell and workspace frame (`docs/specs/410-compact-shell-workspace-frame.md`)
 - [ ] 420 Plan workspace reconciliation (`docs/specs/420-plan-workspace-reconciliation.md`)
 - [ ] 430 Review and rename workspace reconciliation (`docs/specs/430-review-rename-workspace-reconciliation.md`)
 

--- a/src/Renamer.Tests/UI/ShellCopyTests.cs
+++ b/src/Renamer.Tests/UI/ShellCopyTests.cs
@@ -1,0 +1,13 @@
+using Renamer.UI.Resources.Strings;
+
+namespace Renamer.Tests.UI;
+
+public sealed class ShellCopyTests
+{
+    [Fact]
+    public void MainPageCopyUsesCompactAppShell()
+    {
+        Assert.Equal("Renamer", AppStrings.MainPageHeading);
+        Assert.Equal("Plan · Review · Rename", AppStrings.MainPageDescription);
+    }
+}

--- a/src/Renamer.UI/MainPage.xaml
+++ b/src/Renamer.UI/MainPage.xaml
@@ -17,24 +17,24 @@
     </ContentPage.MenuBarItems>
 
     <Grid RowDefinitions="Auto,*"
-          Padding="24"
-          RowSpacing="18">
+          Padding="24,18,24,24"
+          RowSpacing="12">
 
-        <!-- Header row: title/description left, theme picker right -->
+        <!-- Header row: compact app title left, theme picker right -->
         <Grid ColumnDefinitions="*,Auto">
-            <VerticalStackLayout Spacing="6">
+            <VerticalStackLayout Spacing="3">
                 <Label Text="{x:Static strings:AppStrings.MainPageHeading}"
-                       FontSize="32"
+                       FontSize="28"
                        FontAttributes="Bold"
                        SemanticProperties.HeadingLevel="Level1" />
                 <Label Text="{x:Static strings:AppStrings.MainPageDescription}"
-                       FontSize="14"
+                       FontSize="13"
                        TextColor="{DynamicResource TextMuted}" />
             </VerticalStackLayout>
 
             <Border Grid.Column="1"
                     x:Name="ThemePill"
-                    Padding="12,8"
+                    Padding="10,6"
                     VerticalOptions="Center"
                     StrokeShape="RoundRectangle 8"
                     Stroke="{DynamicResource BorderPrimary}"
@@ -51,32 +51,18 @@
         <!-- Main content: rail left, workspace right -->
         <Grid Grid.Row="1"
               ColumnDefinitions="72,*"
-              ColumnSpacing="0">
+              ColumnSpacing="12">
             <ScrollView>
                 <views:WorkflowRailView />
             </ScrollView>
 
-            <Grid Grid.Column="1"
-                  ZIndex="1">
-                <Border Padding="16"
-                        Background="{DynamicResource BackgroundSecondary}"
-                        Stroke="{DynamicResource BorderPrimary}">
-                    <ScrollView>
-                        <Grid>
-                            <views:GenerateWorkspaceView IsVisible="{Binding IsGenerateStepActive}" />
-                            <views:PreviewWorkspaceView IsVisible="{Binding IsPreviewStepActive}" />
-                            <views:ApplyWorkspaceView IsVisible="{Binding IsApplyStepActive}" />
-                        </Grid>
-                    </ScrollView>
-                </Border>
-
-                <BoxView WidthRequest="2"
-                         Margin="-1,0,0,0"
-                         HorizontalOptions="Start"
-                         VerticalOptions="Fill"
-                         BackgroundColor="{DynamicResource BackgroundSecondary}"
-                         ZIndex="3" />
-            </Grid>
+            <ScrollView Grid.Column="1">
+                <Grid>
+                    <views:GenerateWorkspaceView IsVisible="{Binding IsGenerateStepActive}" />
+                    <views:PreviewWorkspaceView IsVisible="{Binding IsPreviewStepActive}" />
+                    <views:ApplyWorkspaceView IsVisible="{Binding IsApplyStepActive}" />
+                </Grid>
+            </ScrollView>
         </Grid>
     </Grid>
 </ContentPage>

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -118,11 +118,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MainPageHeading" xml:space="preserve">
-    <value>Rename your folders in three steps</value>
+    <value>Renamer</value>
     <comment/>
   </data>
   <data name="MainPageDescription" xml:space="preserve">
-    <value>Build a plan, review the changes, then rename the folders when you're ready.</value>
+    <value>Plan · Review · Rename</value>
     <comment/>
   </data>
   <data name="WorkflowRailHeader" xml:space="preserve">


### PR DESCRIPTION
## Summary
- Replace the landing-scale top header with compact app-shell copy: `Renamer` plus `Plan · Review · Rename`.
- Tighten `MainPage` spacing and remove the extra workspace wrapper so the rail and active workspace read as peers.
- Add a focused shell-copy test and mark slice `410` complete in the checklist.

## Verification
- `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~ShellCopy"` — red before resource/layout changes, green after.
- `dotnet restore Renamer.sln`
- `dotnet build src/Renamer.UI/Renamer.UI.csproj`
- `dotnet build Renamer.sln`
- `dotnet test Renamer.sln` — 133 passed, 0 failed.

## Native visual check
- Opened the built Mac Catalyst app from `src/Renamer.UI/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Renamer.UI.app`.
- Verified Plan workspace in dark mode through Computer Use: compact `Renamer` header, `Plan · Review · Rename` breadcrumb, no old hero heading.
- Toggled to explicit light mode and verified the same compact shell treatment.
- `screencapture` could not create an image from the display in this environment, so screenshot evidence is in the Computer Use transcript rather than committed image files.

## Notes
No matching GitHub issue was found for this slice.
