### PR TITLE
refactor(ui): 420 plan workspace reconciliation

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -51,7 +51,7 @@
 ## UI reconciliation v3 (one PR per item)
 - [x] 400 UI reconciliation spec (`docs/specs/400-ui-reconciliation-spec.md`)
 - [x] 410 Compact shell and workspace frame (`docs/specs/410-compact-shell-workspace-frame.md`)
-- [ ] 420 Plan workspace reconciliation (`docs/specs/420-plan-workspace-reconciliation.md`)
+- [x] 420 Plan workspace reconciliation (`docs/specs/420-plan-workspace-reconciliation.md`)
 - [ ] 430 Review and rename workspace reconciliation (`docs/specs/430-review-rename-workspace-reconciliation.md`)
 
 ## Validation

--- a/docs/specs/420-plan-workspace-reconciliation.md
+++ b/docs/specs/420-plan-workspace-reconciliation.md
@@ -12,9 +12,12 @@ Align the Plan workspace with the target concept: one compact folder row, second
   - `target-plan-advanced-expanded.png`
 - Preserve inline browse behavior from slice `350`.
 - Preserve smart defaults and advanced override behavior from slice `360`.
+- Preserve the thin rail behavior from slice `340`, but use short readable rail labels (`Plan`, `Review`, `Rename`) instead of vertically spelling the longer workspace titles.
 - Move the primary `Build plan` action into a bottom action area.
 - Place discovered-folder/status text near the bottom-left action area.
 - Reduce instructional copy to the minimum needed to operate the screen.
+- Keep the workspace content naturally sized: collapsed controls must not reserve visible space, and the card must not use fixed/minimum height just to push actions downward.
+- Preserve readable desktop typography close to the target references; avoid shrinking workspace titles, body copy, labels, or status text to compensate for layout density.
 - Capture native Plan screenshots after implementation.
 
 ## Out of scope
@@ -36,8 +39,10 @@ Align the Plan workspace with the target concept: one compact folder row, second
 1. Compare the current native Plan screenshots with both target Plan references.
 2. Rework `GenerateWorkspaceView.xaml` spacing and grouping so the path row, advanced disclosure, status, and action placement match the concept.
 3. Keep command bindings and ViewModel behavior unchanged unless the layout needs a small display-only property.
-4. Ensure light and dark themes remain legible.
-5. Capture collapsed and expanded native Plan screenshots for PR notes.
+4. Keep the collapsed state visually compact with no artificial blank panel area; the bottom action row should sit after the active content rather than at the bottom of reserved empty space.
+5. Update the rail label source/size only as needed so the current app shell reads as `Plan`, `Review`, `Rename` at a legible size.
+6. Ensure light and dark themes remain legible.
+7. Capture collapsed and expanded native Plan screenshots for PR notes.
 
 ## Commands to run
 1. `dotnet restore Renamer.sln`
@@ -55,8 +60,12 @@ Align the Plan workspace with the target concept: one compact folder row, second
 ## Acceptance checks
 - Plan workspace shows one compact photo-folder row with inline browse.
 - Advanced defaults are secondary and collapsed by default unless overridden.
-- `Build plan` appears as the single primary action in the bottom action area.
-- Status/discovered-folder text appears near the bottom-left action area.
+- Collapsed advanced controls do not reserve visible layout space.
+- The Plan card sizes to its visible content; no fixed/minimum card height creates an empty void.
+- Typography remains readable and close to the concept scale: workspace title and body copy must not be made smaller to force density.
+- Workflow rail labels read as short step names (`Plan`, `Review`, `Rename`) at a legible size.
+- `Build plan` appears as the single primary action at the bottom-right of the visible content flow.
+- Status/discovered-folder text appears bottom-left in the same action row.
 - Native screenshots are captured for collapsed and expanded states.
 
 ## Tests

--- a/src/Renamer.Tests/UI/PlanViewModelDefaultsTests.cs
+++ b/src/Renamer.Tests/UI/PlanViewModelDefaultsTests.cs
@@ -60,6 +60,14 @@ public sealed class PlanViewModelDefaultsTests
     }
 
     [Fact]
+    public void GenerationStatusMessage_DefaultsToPhotoFolderOnlyPrompt()
+    {
+        var vm = MakeViewModel();
+
+        Assert.Equal("Choose a photo folder to build a plan.", vm.GenerationStatusMessage);
+    }
+
+    [Fact]
     public void HasAdvancedOverrides_WhenOutputAutoFilled_RemainsFlase()
     {
         var vm = MakeViewModel();

--- a/src/Renamer.Tests/UI/WorkflowRailItemTests.cs
+++ b/src/Renamer.Tests/UI/WorkflowRailItemTests.cs
@@ -23,6 +23,17 @@ public sealed class WorkflowRailItemTests
         Assert.Equal(["P", "L", "A", "N"], item.TitleCharacters);
     }
 
+    [Theory]
+    [InlineData(PlanWorkflowStep.GeneratePlan, new[] { "P", "L", "A", "N" })]
+    [InlineData(PlanWorkflowStep.PreviewPlan, new[] { "R", "E", "V", "I", "E", "W" })]
+    [InlineData(PlanWorkflowStep.ApplyPlan, new[] { "R", "E", "N", "A", "M", "E" })]
+    public void RailTitleCharacters_UsesShortWorkflowLabels(PlanWorkflowStep step, string[] expected)
+    {
+        var item = MakeItem(step: step, title: "Ignored long title");
+
+        Assert.Equal(expected, item.RailTitleCharacters);
+    }
+
     [Fact]
     public void StepNumber_MapsEnumToOrdinal()
     {

--- a/src/Renamer.UI/Plans/PlanWorkflowStepItem.cs
+++ b/src/Renamer.UI/Plans/PlanWorkflowStepItem.cs
@@ -38,6 +38,13 @@ public sealed class PlanWorkflowStepItem : INotifyPropertyChanged
              .Select(c => c.ToString())
              .ToList();
 
+    public IReadOnlyList<string> RailTitleCharacters => Step switch
+    {
+        PlanWorkflowStep.GeneratePlan => ToCharacters(AppStrings.StepGenerateRailTitle),
+        PlanWorkflowStep.PreviewPlan => ToCharacters(AppStrings.StepPreviewRailTitle),
+        _ => ToCharacters(AppStrings.StepApplyRailTitle)
+    };
+
     public string IndicatorState
     {
         get
@@ -100,4 +107,10 @@ public sealed class PlanWorkflowStepItem : INotifyPropertyChanged
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    private static IReadOnlyList<string> ToCharacters(string value) =>
+        value.Trim().ToUpperInvariant()
+             .Where(c => !char.IsWhiteSpace(c))
+             .Select(c => c.ToString())
+             .ToList();
 }

--- a/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
@@ -48,10 +48,13 @@ namespace Renamer.UI.Resources.Strings
         internal static string WorkflowRailDescription => ResourceManager.GetString("WorkflowRailDescription", resourceCulture)!;
 
         internal static string StepGenerateTitle => ResourceManager.GetString("StepGenerateTitle", resourceCulture)!;
+        internal static string StepGenerateRailTitle => ResourceManager.GetString("StepGenerateRailTitle", resourceCulture)!;
         internal static string StepGenerateDescription => ResourceManager.GetString("StepGenerateDescription", resourceCulture)!;
         internal static string StepPreviewTitle => ResourceManager.GetString("StepPreviewTitle", resourceCulture)!;
+        internal static string StepPreviewRailTitle => ResourceManager.GetString("StepPreviewRailTitle", resourceCulture)!;
         internal static string StepPreviewDescription => ResourceManager.GetString("StepPreviewDescription", resourceCulture)!;
         internal static string StepApplyTitle => ResourceManager.GetString("StepApplyTitle", resourceCulture)!;
+        internal static string StepApplyRailTitle => ResourceManager.GetString("StepApplyRailTitle", resourceCulture)!;
         internal static string StepApplyDescription => ResourceManager.GetString("StepApplyDescription", resourceCulture)!;
         internal static string StepStatusDone => ResourceManager.GetString("StepStatusDone", resourceCulture)!;
         internal static string StepStatusError => ResourceManager.GetString("StepStatusError", resourceCulture)!;

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -137,6 +137,10 @@
     <value>Build a plan</value>
     <comment/>
   </data>
+  <data name="StepGenerateRailTitle" xml:space="preserve">
+    <value>Plan</value>
+    <comment/>
+  </data>
   <data name="StepGenerateDescription" xml:space="preserve">
     <value>Choose a photo folder and create a rename plan.</value>
     <comment/>
@@ -145,12 +149,20 @@
     <value>Review the plan</value>
     <comment/>
   </data>
+  <data name="StepPreviewRailTitle" xml:space="preserve">
+    <value>Review</value>
+    <comment/>
+  </data>
   <data name="StepPreviewDescription" xml:space="preserve">
     <value>Check the proposed folder names before you make changes.</value>
     <comment/>
   </data>
   <data name="StepApplyTitle" xml:space="preserve">
     <value>Rename folders</value>
+    <comment/>
+  </data>
+  <data name="StepApplyRailTitle" xml:space="preserve">
+    <value>Rename</value>
     <comment/>
   </data>
   <data name="StepApplyDescription" xml:space="preserve">
@@ -170,11 +182,11 @@
     <comment/>
   </data>
   <data name="GenerateHeading" xml:space="preserve">
-    <value>Build a plan</value>
+    <value>Pick a folder</value>
     <comment/>
   </data>
   <data name="GenerateDescription" xml:space="preserve">
-    <value>Choose your photo folder and where to save the plan, then review the folder names before anything changes.</value>
+    <value>Choose the folder of photos you'd like to rename.</value>
     <comment/>
   </data>
   <data name="GenerateSectionHeader" xml:space="preserve">
@@ -242,7 +254,7 @@
     <comment>Ellipsis glyph shown on inline browse buttons beside path fields</comment>
   </data>
   <data name="GenerateStatusDefault" xml:space="preserve">
-    <value>Choose a photo folder and a save folder to build a plan.</value>
+    <value>Choose a photo folder to build a plan.</value>
     <comment/>
   </data>
   <data name="GenerateStatusRootCanceled" xml:space="preserve">

--- a/src/Renamer.UI/Resources/Styles/Styles.xaml
+++ b/src/Renamer.UI/Resources/Styles/Styles.xaml
@@ -186,6 +186,14 @@
         <Setter Property="Margin" Value="0,0,0,8" />
     </Style>
 
+    <Style TargetType="Border" x:Key="FieldFrame">
+        <Setter Property="Background" Value="{DynamicResource BackgroundSecondary}" />
+        <Setter Property="Stroke" Value="{DynamicResource BorderPrimary}" />
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="StrokeShape" Value="RoundRectangle 8" />
+        <Setter Property="Padding" Value="8,0" />
+    </Style>
+
     <Style TargetType="Button" x:Key="BrowseButton">
         <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
         <Setter Property="TextColor" Value="{DynamicResource TextSecondary}" />
@@ -198,6 +206,60 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="MinimumHeightRequest" Value="44" />
         <Setter Property="MinimumWidthRequest" Value="36" />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="{DynamicResource TextMuted}" />
+                            <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style TargetType="Button" x:Key="SecondaryButton">
+        <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
+        <Setter Property="TextColor" Value="{DynamicResource TextPrimary}" />
+        <Setter Property="BorderColor" Value="{DynamicResource BorderPrimary}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="Padding" Value="14,10" />
+        <Setter Property="MinimumHeightRequest" Value="44" />
+        <Setter Property="MinimumWidthRequest" Value="44" />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="{DynamicResource TextMuted}" />
+                            <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style TargetType="Button" x:Key="CompactSecondaryButton">
+        <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundTertiary}" />
+        <Setter Property="TextColor" Value="{DynamicResource TextPrimary}" />
+        <Setter Property="BorderColor" Value="{DynamicResource BorderPrimary}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="CornerRadius" Value="6" />
+        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="Padding" Value="10,6" />
+        <Setter Property="MinimumHeightRequest" Value="32" />
+        <Setter Property="MinimumWidthRequest" Value="44" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">

--- a/src/Renamer.UI/Resources/Themes/LightTheme.xaml
+++ b/src/Renamer.UI/Resources/Themes/LightTheme.xaml
@@ -29,7 +29,7 @@
     <Color x:Key="ButtonText">#FFFFFF</Color>
 
     <!-- Surfaces and borders -->
-    <Color x:Key="BorderPrimary">#CBD5E1</Color>
+    <Color x:Key="BorderPrimary">#94A3B8</Color>
     <Color x:Key="BadgeBackground">#E2E8F0</Color>
     <Color x:Key="DividerColor">#D8D8D8</Color>
 

--- a/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/GenerateWorkspaceView.xaml
@@ -11,26 +11,22 @@
                    FontSize="24"
                    FontAttributes="Bold" />
             <Label Text="{x:Static strings:AppStrings.GenerateDescription}"
-                   FontSize="13"
+                   FontSize="14"
                    TextColor="{DynamicResource TextSecondary}" />
         </VerticalStackLayout>
 
-        <Border Padding="16">
-            <VerticalStackLayout Spacing="12">
-                <Label Text="{x:Static strings:AppStrings.GenerateSectionHeader}"
-                       FontSize="18"
-                       FontAttributes="Bold" />
-                <Label Text="{x:Static strings:AppStrings.GenerateInstructions}"
-                       FontSize="13" />
-
+        <Border Padding="18">
+            <VerticalStackLayout Spacing="14">
                 <VerticalStackLayout Spacing="6">
                     <Label Text="{x:Static strings:AppStrings.GenerateLabelRootFolder}"
                            FontAttributes="Bold" />
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                        <Entry Grid.Column="0"
-                               Text="{Binding GenerationRootPath}"
-                               Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderRootFolder}"
-                               ClearButtonVisibility="WhileEditing" />
+                        <Border Grid.Column="0"
+                                Style="{DynamicResource FieldFrame}">
+                            <Entry Text="{Binding GenerationRootPath}"
+                                   Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderRootFolder}"
+                                   ClearButtonVisibility="WhileEditing" />
+                        </Border>
                         <Button Grid.Column="1"
                                 Style="{DynamicResource BrowseButton}"
                                 Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
@@ -40,16 +36,21 @@
                     </Grid>
                 </VerticalStackLayout>
 
-                <VerticalStackLayout Spacing="4">
+                <Grid ColumnDefinitions="*,Auto"
+                      ColumnSpacing="12"
+                      Padding="0,2,0,0">
                     <Label Text="{x:Static strings:AppStrings.GenerateAdvancedDisclosureHelpCollapsed}"
                            x:Name="AdvancedCollapsedHint"
-                           FontSize="12"
+                           FontSize="13"
+                           VerticalOptions="Center"
                            TextColor="{DynamicResource TextSecondary}" />
                     <Button x:Name="AdvancedToggle"
+                            Grid.Column="1"
+                            Style="{DynamicResource CompactSecondaryButton}"
                             Text="{x:Static strings:AppStrings.GenerateAdvancedDisclosureLabel}"
                             Clicked="OnAdvancedToggleClicked"
-                            HorizontalOptions="Start" />
-                </VerticalStackLayout>
+                            HorizontalOptions="End" />
+                </Grid>
 
                 <VerticalStackLayout x:Name="AdvancedPanel"
                                      Spacing="12"
@@ -58,10 +59,12 @@
                         <Label Text="{x:Static strings:AppStrings.GenerateLabelOutputFolder}"
                                FontAttributes="Bold" />
                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                            <Entry Grid.Column="0"
-                                   Text="{Binding GenerationOutputDirectoryPath}"
-                                   Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderOutputFolder}"
-                                   ClearButtonVisibility="WhileEditing" />
+                            <Border Grid.Column="0"
+                                    Style="{DynamicResource FieldFrame}">
+                                <Entry Text="{Binding GenerationOutputDirectoryPath}"
+                                       Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderOutputFolder}"
+                                       ClearButtonVisibility="WhileEditing" />
+                            </Border>
                             <Button Grid.Column="1"
                                     Style="{DynamicResource BrowseButton}"
                                     Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
@@ -74,32 +77,42 @@
                     <VerticalStackLayout Spacing="6">
                         <Label Text="{x:Static strings:AppStrings.GenerateLabelPlanFileName}"
                                FontAttributes="Bold" />
-                        <Entry Text="{Binding PlanFileName}"
-                               Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderPlanFileName}"
-                               ClearButtonVisibility="WhileEditing" />
+                        <Border Style="{DynamicResource FieldFrame}">
+                            <Entry Text="{Binding PlanFileName}"
+                                   Placeholder="{x:Static strings:AppStrings.GeneratePlaceholderPlanFileName}"
+                                   ClearButtonVisibility="WhileEditing" />
+                        </Border>
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Spacing="4">
                         <Label Text="{x:Static strings:AppStrings.GenerateLabelGeneratedPlanPath}"
                                FontAttributes="Bold" />
                         <Label Text="{Binding GeneratedPlanPathPreview}"
-                               FontSize="12"
+                               FontSize="13"
                                LineBreakMode="WordWrap"
                                TextColor="{DynamicResource TextLink}" />
                     </VerticalStackLayout>
                 </VerticalStackLayout>
 
-                <HorizontalStackLayout Spacing="10">
-                    <Button Text="{x:Static strings:AppStrings.GenerateButtonGenerateAndLoad}"
-                            Command="{Binding GeneratePlanCommand}"
-                            IsEnabled="{Binding CanGenerate}" />
-                    <ActivityIndicator IsRunning="{Binding IsGenerating}"
-                                       IsVisible="{Binding IsGenerating}"
-                                       VerticalOptions="Center" />
-                </HorizontalStackLayout>
-
-                <Label Text="{Binding GenerationStatusMessage}"
-                       FontSize="13" />
+                <Grid ColumnDefinitions="*,Auto"
+                      ColumnSpacing="12"
+                      Padding="0,2,0,0">
+                    <Label Text="{Binding GenerationStatusMessage}"
+                           FontSize="14"
+                           VerticalOptions="Center"
+                           LineBreakMode="WordWrap" />
+                    <HorizontalStackLayout Grid.Column="1"
+                                           Spacing="10"
+                                           HorizontalOptions="End"
+                                           VerticalOptions="Center">
+                        <ActivityIndicator IsRunning="{Binding IsGenerating}"
+                                           IsVisible="{Binding IsGenerating}"
+                                           VerticalOptions="Center" />
+                        <Button Text="{x:Static strings:AppStrings.GenerateButtonGenerateAndLoad}"
+                                Command="{Binding GeneratePlanCommand}"
+                                IsEnabled="{Binding CanGenerate}" />
+                    </HorizontalStackLayout>
+                </Grid>
             </VerticalStackLayout>
         </Border>
 

--- a/src/Renamer.UI/Views/WorkflowRailView.xaml
+++ b/src/Renamer.UI/Views/WorkflowRailView.xaml
@@ -71,13 +71,13 @@
 
             <VerticalStackLayout HorizontalOptions="Center"
                                  Spacing="1"
-                                 BindableLayout.ItemsSource="{Binding GenerateStep.TitleCharacters}">
+                                 BindableLayout.ItemsSource="{Binding GenerateStep.RailTitleCharacters}">
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
                         <Label Text="{Binding}"
-                               FontSize="9"
+                               FontSize="14"
                                HorizontalOptions="Center"
-                               TextColor="{DynamicResource TextMuted}" />
+                               TextColor="{DynamicResource TextSecondary}" />
                     </DataTemplate>
                 </BindableLayout.ItemTemplate>
             </VerticalStackLayout>
@@ -152,13 +152,13 @@
 
             <VerticalStackLayout HorizontalOptions="Center"
                                  Spacing="1"
-                                 BindableLayout.ItemsSource="{Binding PreviewStep.TitleCharacters}">
+                                 BindableLayout.ItemsSource="{Binding PreviewStep.RailTitleCharacters}">
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
                         <Label Text="{Binding}"
-                               FontSize="9"
+                               FontSize="14"
                                HorizontalOptions="Center"
-                               TextColor="{DynamicResource TextMuted}" />
+                               TextColor="{DynamicResource TextSecondary}" />
                     </DataTemplate>
                 </BindableLayout.ItemTemplate>
             </VerticalStackLayout>
@@ -233,13 +233,13 @@
 
             <VerticalStackLayout HorizontalOptions="Center"
                                  Spacing="1"
-                                 BindableLayout.ItemsSource="{Binding ApplyStep.TitleCharacters}">
+                                 BindableLayout.ItemsSource="{Binding ApplyStep.RailTitleCharacters}">
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
                         <Label Text="{Binding}"
-                               FontSize="9"
+                               FontSize="14"
                                HorizontalOptions="Center"
-                               TextColor="{DynamicResource TextMuted}" />
+                               TextColor="{DynamicResource TextSecondary}" />
                     </DataTemplate>
                 </BindableLayout.ItemTemplate>
             </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- Reworked the Plan workspace into a compact, content-sized form with a clearer first action: `Pick a folder`.
- Removed the artificial empty Plan card height and kept collapsed Advanced controls from reserving visible space.
- Added explicit field frames and a stronger light-theme border token so text fields remain discernible in light mode.
- Switched the rail to short readable labels (`Plan`, `Review`, `Rename`) at a legible size while preserving full workspace titles.
- Updated slice 420 acceptance criteria to cover natural sizing, typography, light/dark legibility, and readable rail labels.

## Verification
- `dotnet restore Renamer.sln`
- `dotnet build src/Renamer.UI/Renamer.UI.csproj`
- `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~PlanViewModel|FullyQualifiedName~Generate|FullyQualifiedName~WorkflowRailItemTests"` — 52 passed
- `dotnet build Renamer.sln`
- `dotnet test Renamer.sln` — 137 passed

## Native Screenshots
- Light collapsed / rail-size check: `/private/tmp/renamer-420-rail-14-check.png`
- Light field-frame contrast check: `/private/tmp/renamer-420-light-field-frame.png`

No matching GitHub issue was found for this slice.
