### PR TITLE
refactor(ui): 430 review and rename workspace reconciliation

### DIFF
--- a/docs/checklists/v1.md
+++ b/docs/checklists/v1.md
@@ -52,7 +52,7 @@
 - [x] 400 UI reconciliation spec (`docs/specs/400-ui-reconciliation-spec.md`)
 - [x] 410 Compact shell and workspace frame (`docs/specs/410-compact-shell-workspace-frame.md`)
 - [x] 420 Plan workspace reconciliation (`docs/specs/420-plan-workspace-reconciliation.md`)
-- [ ] 430 Review and rename workspace reconciliation (`docs/specs/430-review-rename-workspace-reconciliation.md`)
+- [x] 430 Review and rename workspace reconciliation (`docs/specs/430-review-rename-workspace-reconciliation.md`)
 
 ## Validation
 - [ ] Windows smoke test

--- a/src/Renamer.Tests/UI/PlanViewModelTests.cs
+++ b/src/Renamer.Tests/UI/PlanViewModelTests.cs
@@ -16,8 +16,12 @@ public sealed class PlanViewModelTests
     {
         Assert.Equal("Review the plan", AppStrings.PreviewHeading);
         Assert.Equal("Review plan", AppStrings.PreviewButtonLoad);
+        Assert.Equal("Back to plan", AppStrings.PreviewButtonBackToPlan);
+        Assert.Equal("Reload plan", AppStrings.PreviewButtonReloadPlan);
+        Assert.Equal("Continue", AppStrings.PreviewButtonContinue);
         Assert.Equal("Before you rename", AppStrings.PreviewSummarySectionHeader);
         Assert.Equal("Proposed folder names", AppStrings.PreviewOperationsSectionHeader);
+        Assert.Equal("Review the plan, then rename when you're ready.", AppStrings.ApplyStatusDefault);
     }
 
     [Fact]

--- a/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.Designer.cs
@@ -114,6 +114,9 @@ namespace Renamer.UI.Resources.Strings
         internal static string PreviewPlaceholder => ResourceManager.GetString("PreviewPlaceholder", resourceCulture)!;
         internal static string PreviewBrowse => ResourceManager.GetString("PreviewBrowse", resourceCulture)!;
         internal static string PreviewButtonLoad => ResourceManager.GetString("PreviewButtonLoad", resourceCulture)!;
+        internal static string PreviewButtonBackToPlan => ResourceManager.GetString("PreviewButtonBackToPlan", resourceCulture)!;
+        internal static string PreviewButtonReloadPlan => ResourceManager.GetString("PreviewButtonReloadPlan", resourceCulture)!;
+        internal static string PreviewButtonContinue => ResourceManager.GetString("PreviewButtonContinue", resourceCulture)!;
         internal static string PreviewIdleLabel => ResourceManager.GetString("PreviewIdleLabel", resourceCulture)!;
         internal static string PreviewIdleDescription => ResourceManager.GetString("PreviewIdleDescription", resourceCulture)!;
         internal static string PreviewLoadingLabel => ResourceManager.GetString("PreviewLoadingLabel", resourceCulture)!;

--- a/src/Renamer.UI/Resources/Strings/AppStrings.resx
+++ b/src/Renamer.UI/Resources/Strings/AppStrings.resx
@@ -377,6 +377,18 @@
     <value>Review plan</value>
     <comment/>
   </data>
+  <data name="PreviewButtonBackToPlan" xml:space="preserve">
+    <value>Back to plan</value>
+    <comment/>
+  </data>
+  <data name="PreviewButtonReloadPlan" xml:space="preserve">
+    <value>Reload plan</value>
+    <comment/>
+  </data>
+  <data name="PreviewButtonContinue" xml:space="preserve">
+    <value>Continue</value>
+    <comment/>
+  </data>
   <data name="PreviewIdleLabel" xml:space="preserve">
     <value>Ready to review</value>
     <comment/>
@@ -634,7 +646,7 @@
     <comment/>
   </data>
   <data name="ApplyStatusDefault" xml:space="preserve">
-    <value>Load a reviewed plan before you rename folders.</value>
+    <value>Review the plan, then rename when you're ready.</value>
     <comment/>
   </data>
   <data name="ApplyStatusOutcomeDefault" xml:space="preserve">

--- a/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/ApplyWorkspaceView.xaml
@@ -6,28 +6,40 @@
              xmlns:strings="clr-namespace:Renamer.UI.Resources.Strings"
              x:Class="Renamer.UI.Views.ApplyWorkspaceView"
              x:DataType="plans:IPlanViewModel">
-    <VerticalStackLayout Spacing="18">
+    <VerticalStackLayout Spacing="16">
         <VerticalStackLayout Spacing="4">
             <Label Text="{x:Static strings:AppStrings.ApplyHeading}"
                    FontSize="24"
                    FontAttributes="Bold" />
             <Label Text="{x:Static strings:AppStrings.ApplyDescription}"
-                   FontSize="13"
+                   FontSize="14"
                    TextColor="{DynamicResource TextSecondary}" />
         </VerticalStackLayout>
 
-        <Border Padding="16">
-            <VerticalStackLayout Spacing="12">
-                <Label Text="{x:Static strings:AppStrings.ApplyPlanArtifactSectionHeader}"
-                       FontSize="18"
-                       FontAttributes="Bold" />
-                <Label Text="{x:Static strings:AppStrings.ApplyPlanArtifactInstructions}"
-                       FontSize="13" />
+        <Border Padding="18">
+            <Border.Triggers>
+                <DataTrigger TargetType="Border"
+                             Binding="{Binding IsLoaded}"
+                             Value="True">
+                    <Setter Property="IsVisible" Value="False" />
+                </DataTrigger>
+            </Border.Triggers>
+            <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="4">
+                    <Label Text="{x:Static strings:AppStrings.ApplyPlanArtifactSectionHeader}"
+                           FontSize="18"
+                           FontAttributes="Bold" />
+                    <Label Text="{x:Static strings:AppStrings.ApplyPlanArtifactInstructions}"
+                           FontSize="14"
+                           TextColor="{DynamicResource TextSecondary}" />
+                </VerticalStackLayout>
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                    <Entry Grid.Column="0"
-                           Text="{Binding PlanPath}"
-                           Placeholder="{x:Static strings:AppStrings.PreviewPlaceholder}"
-                           ClearButtonVisibility="WhileEditing" />
+                    <Border Grid.Column="0"
+                            Style="{DynamicResource FieldFrame}">
+                        <Entry Text="{Binding PlanPath}"
+                               Placeholder="{x:Static strings:AppStrings.PreviewPlaceholder}"
+                               ClearButtonVisibility="WhileEditing" />
+                    </Border>
                     <Button Grid.Column="1"
                             Style="{DynamicResource BrowseButton}"
                             Text="{x:Static strings:AppStrings.BrowseButtonGlyph}"
@@ -35,15 +47,19 @@
                             AutomationProperties.Name="{x:Static strings:AppStrings.ApplyButtonBrowse}"
                             ToolTipProperties.Text="{x:Static strings:AppStrings.ApplyButtonBrowse}" />
                 </Grid>
-                <HorizontalStackLayout Spacing="10">
-                    <Button Text="{x:Static strings:AppStrings.ApplyButtonLoadPlan}"
-                            Command="{Binding LoadPreviewCommand}" />
-                    <ActivityIndicator IsRunning="{Binding IsLoading}"
+                <Label Text="{Binding StatusMessage}"
+                       FontSize="14"
+                       LineBreakMode="WordWrap" />
+                <Grid ColumnDefinitions="*,Auto,Auto"
+                      ColumnSpacing="10">
+                    <ActivityIndicator Grid.Column="1"
+                                       IsRunning="{Binding IsLoading}"
                                        IsVisible="{Binding IsLoading}"
                                        VerticalOptions="Center" />
-                </HorizontalStackLayout>
-                <Label Text="{Binding StatusMessage}"
-                       FontSize="13" />
+                    <Button Grid.Column="2"
+                            Text="{x:Static strings:AppStrings.ApplyButtonLoadPlan}"
+                            Command="{Binding LoadPreviewCommand}" />
+                </Grid>
             </VerticalStackLayout>
         </Border>
 
@@ -55,28 +71,38 @@
                        FontAttributes="Bold"
                        TextColor="{DynamicResource StatusError}" />
                 <Label Text="{Binding ErrorMessage}"
-                       FontSize="13" />
+                       FontSize="14"
+                       LineBreakMode="WordWrap" />
             </VerticalStackLayout>
         </Border>
 
-        <Border Padding="16">
-            <VerticalStackLayout Spacing="12">
-                <Label Text="{x:Static strings:AppStrings.ApplySectionHeader}"
+        <Border Padding="18">
+            <Grid ColumnDefinitions="*,Auto,Auto"
+                  RowDefinitions="Auto,Auto"
+                  ColumnSpacing="10"
+                  RowSpacing="8">
+                <Label Grid.Column="0"
+                       Grid.Row="0"
+                       Text="{x:Static strings:AppStrings.ApplySectionHeader}"
                        FontSize="18"
                        FontAttributes="Bold" />
-                <Label Text="{x:Static strings:AppStrings.ApplyInstructions}"
-                       FontSize="13" />
-                <HorizontalStackLayout Spacing="10">
-                    <Button Text="{x:Static strings:AppStrings.ApplyButtonRun}"
-                            Command="{Binding ApplyCommand}"
-                            IsEnabled="{Binding CanApply}" />
-                    <ActivityIndicator IsRunning="{Binding IsApplying}"
-                                       IsVisible="{Binding IsApplying}"
-                                       VerticalOptions="Center" />
-                </HorizontalStackLayout>
-                <Label Text="{Binding ApplyStatusMessage}"
-                       FontSize="13" />
-            </VerticalStackLayout>
+                <Label Grid.Column="0"
+                       Grid.Row="1"
+                       Text="{Binding ApplyStatusMessage}"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"
+                       VerticalOptions="Center" />
+                <ActivityIndicator Grid.Column="1"
+                                   Grid.Row="1"
+                                   IsRunning="{Binding IsApplying}"
+                                   IsVisible="{Binding IsApplying}"
+                                   VerticalOptions="Center" />
+                <Button Grid.Column="2"
+                        Grid.Row="1"
+                        Text="{x:Static strings:AppStrings.ApplyButtonRun}"
+                        Command="{Binding ApplyCommand}"
+                        IsEnabled="{Binding CanApply}" />
+            </Grid>
         </Border>
 
         <Border Padding="16"
@@ -87,22 +113,32 @@
                        FontAttributes="Bold"
                        TextColor="{DynamicResource StatusError}" />
                 <Label Text="{Binding ApplyErrorMessage}"
-                       FontSize="13" />
+                       FontSize="14"
+                       LineBreakMode="WordWrap" />
             </VerticalStackLayout>
         </Border>
 
-        <Border Padding="16">
+        <Border Padding="16"
+                IsVisible="{Binding HasApplyReport}">
             <VerticalStackLayout Spacing="8">
-                <Label Text="{Binding ApplyResultHeadline}"
-                       FontSize="22"
-                       FontAttributes="Bold" />
-                <Label Text="{Binding ApplyResultBreakdown}"
-                       FontSize="13"
-                       TextColor="{DynamicResource TextSecondary}" />
-                <Button x:Name="DetailsToggle"
-                        Text="{x:Static strings:AppStrings.ApplyResultDetailsLabel}"
-                        Clicked="OnDetailsToggleClicked"
-                        HorizontalOptions="Start" />
+                <Grid ColumnDefinitions="*,Auto"
+                      ColumnSpacing="10">
+                    <VerticalStackLayout Grid.Column="0"
+                                         Spacing="3">
+                        <Label Text="{Binding ApplyResultHeadline}"
+                               FontSize="20"
+                               FontAttributes="Bold" />
+                        <Label Text="{Binding ApplyResultBreakdown}"
+                               FontSize="14"
+                               TextColor="{DynamicResource TextSecondary}" />
+                    </VerticalStackLayout>
+                    <Button x:Name="DetailsToggle"
+                            Grid.Column="1"
+                            Style="{DynamicResource CompactSecondaryButton}"
+                            Text="{x:Static strings:AppStrings.ApplyResultDetailsLabel}"
+                            Clicked="OnDetailsToggleClicked"
+                            VerticalOptions="Center" />
+                </Grid>
                 <VerticalStackLayout x:Name="DetailsPanel"
                                      Spacing="14"
                                      IsVisible="False">
@@ -161,12 +197,12 @@
             </VerticalStackLayout>
         </Border>
 
-        <VerticalStackLayout Spacing="12">
+        <VerticalStackLayout Spacing="12"
+                             IsVisible="{Binding HasApplyReport}">
             <Label Text="{x:Static strings:AppStrings.ApplyResultsSectionHeader}"
                    FontSize="18"
                    FontAttributes="Bold" />
             <VerticalStackLayout Spacing="0"
-                                 IsVisible="{Binding HasApplyReport}"
                                  BindableLayout.ItemsSource="{Binding ApplyResults}">
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="model:ApplyResultItem">

--- a/src/Renamer.UI/Views/PreviewWorkspaceView.xaml
+++ b/src/Renamer.UI/Views/PreviewWorkspaceView.xaml
@@ -6,45 +6,76 @@
              xmlns:strings="clr-namespace:Renamer.UI.Resources.Strings"
              x:Class="Renamer.UI.Views.PreviewWorkspaceView"
              x:DataType="plans:IPlanViewModel">
-    <VerticalStackLayout Spacing="18">
+    <VerticalStackLayout Spacing="16">
         <VerticalStackLayout Spacing="4">
             <Label Text="{x:Static strings:AppStrings.PreviewHeading}"
                    FontSize="24"
                    FontAttributes="Bold" />
             <Label Text="{x:Static strings:AppStrings.PreviewDescription}"
-                   FontSize="13"
+                   FontSize="14"
                    TextColor="{DynamicResource TextSecondary}" />
         </VerticalStackLayout>
 
-        <Border Padding="16">
-            <VerticalStackLayout Spacing="12">
-                <Label Text="{x:Static strings:AppStrings.PreviewSectionHeader}"
-                       FontSize="18"
-                       FontAttributes="Bold" />
-                <Label Text="{x:Static strings:AppStrings.PreviewInstructions}"
-                       FontSize="13" />
-                <Entry Text="{Binding PlanPath}"
-                       Placeholder="{x:Static strings:AppStrings.PreviewPlaceholder}"
-                       ClearButtonVisibility="WhileEditing" />
-                <HorizontalStackLayout Spacing="10">
-                    <Button Text="{x:Static strings:AppStrings.PreviewBrowse}"
+        <Border Padding="18">
+            <Border.Triggers>
+                <DataTrigger TargetType="Border"
+                             Binding="{Binding IsLoaded}"
+                             Value="True">
+                    <Setter Property="IsVisible" Value="False" />
+                </DataTrigger>
+                <DataTrigger TargetType="Border"
+                             Binding="{Binding IsLoading}"
+                             Value="True">
+                    <Setter Property="IsVisible" Value="False" />
+                </DataTrigger>
+            </Border.Triggers>
+            <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="4">
+                    <Label Text="{x:Static strings:AppStrings.PreviewSectionHeader}"
+                           FontSize="18"
+                           FontAttributes="Bold" />
+                    <Label Text="{x:Static strings:AppStrings.PreviewInstructions}"
+                           FontSize="14"
+                           TextColor="{DynamicResource TextSecondary}" />
+                </VerticalStackLayout>
+
+                <Grid ColumnDefinitions="*,Auto"
+                      ColumnSpacing="6">
+                    <Border Grid.Column="0"
+                            Style="{DynamicResource FieldFrame}">
+                        <Entry Text="{Binding PlanPath}"
+                               Placeholder="{x:Static strings:AppStrings.PreviewPlaceholder}"
+                               ClearButtonVisibility="WhileEditing" />
+                    </Border>
+                    <Button Grid.Column="1"
+                            Style="{DynamicResource SecondaryButton}"
+                            Text="{x:Static strings:AppStrings.PreviewBrowse}"
                             Command="{Binding BrowsePlanCommand}" />
-                    <Button Text="{x:Static strings:AppStrings.PreviewButtonLoad}"
+                </Grid>
+
+                <Grid ColumnDefinitions="*,Auto"
+                      ColumnSpacing="12">
+                    <Label Text="{Binding StatusMessage}"
+                           FontSize="14"
+                           VerticalOptions="Center"
+                           LineBreakMode="WordWrap" />
+                    <Button Grid.Column="1"
+                            Text="{x:Static strings:AppStrings.PreviewButtonLoad}"
                             Command="{Binding LoadPreviewCommand}" />
-                </HorizontalStackLayout>
-                <Label Text="{Binding StatusMessage}"
-                       FontSize="13" />
+                </Grid>
             </VerticalStackLayout>
         </Border>
 
         <Border Padding="16"
-                IsVisible="{Binding IsIdle}">
+                IsVisible="{Binding HasError}">
             <VerticalStackLayout Spacing="8">
-                <Label Text="{x:Static strings:AppStrings.PreviewIdleLabel}"
-                       FontSize="18"
-                       FontAttributes="Bold" />
-                <Label Text="{x:Static strings:AppStrings.PreviewIdleDescription}"
-                       FontSize="13" />
+                <Label Text="{x:Static strings:AppStrings.PreviewErrorHeading}"
+                       FontSize="16"
+                       FontAttributes="Bold"
+                       TextColor="{DynamicResource StatusError}" />
+                <Label Text="{Binding ErrorMessage}"
+                       FontSize="14"
+                       LineBreakMode="WordWrap" />
             </VerticalStackLayout>
         </Border>
 
@@ -61,63 +92,73 @@
                        FontAttributes="Bold"
                        HorizontalTextAlignment="Center" />
                 <Label Text="{Binding StatusMessage}"
-                       FontSize="13"
+                       FontSize="14"
                        HorizontalTextAlignment="Center" />
             </VerticalStackLayout>
         </Border>
 
         <Border Padding="16"
-                IsVisible="{Binding HasError}">
+                IsVisible="{Binding IsIdle}">
             <VerticalStackLayout Spacing="8">
-                <Label Text="{x:Static strings:AppStrings.PreviewErrorHeading}"
-                       FontSize="16"
-                       FontAttributes="Bold"
-                       TextColor="{DynamicResource StatusError}" />
-                <Label Text="{Binding ErrorMessage}"
-                       FontSize="13" />
+                <Label Text="{x:Static strings:AppStrings.PreviewIdleLabel}"
+                       FontSize="18"
+                       FontAttributes="Bold" />
+                <Label Text="{x:Static strings:AppStrings.PreviewIdleDescription}"
+                       FontSize="14" />
             </VerticalStackLayout>
         </Border>
 
-        <VerticalStackLayout Spacing="18"
+        <VerticalStackLayout Spacing="14"
                              IsVisible="{Binding IsLoaded}">
             <Border Padding="16">
-                <VerticalStackLayout Spacing="12">
-                    <Border Padding="14"
-                            Background="{DynamicResource BackgroundTertiary}">
-                        <VerticalStackLayout Spacing="6">
-                            <Label Text="{x:Static strings:AppStrings.PreviewFieldRootPath}"
-                                   FontAttributes="Bold" />
-                            <Label Text="{Binding RootPath}"
-                                   LineBreakMode="WordWrap"
-                                   TextColor="{DynamicResource TextLink}">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer Command="{Binding OpenRootPathCommand}" />
-                                </Label.GestureRecognizers>
-                            </Label>
-                        </VerticalStackLayout>
-                    </Border>
+                <Grid ColumnDefinitions="*,Auto,Auto"
+                      ColumnSpacing="10"
+                      RowDefinitions="Auto,Auto"
+                      RowSpacing="12">
+                    <VerticalStackLayout Grid.Column="0"
+                                         Grid.Row="0"
+                                         Grid.RowSpan="2"
+                                         Spacing="4">
+                        <Label Text="{x:Static strings:AppStrings.PreviewSummarySectionHeader}"
+                               FontSize="18"
+                               FontAttributes="Bold" />
+                        <Label Text="{Binding RootPath}"
+                               FontSize="14"
+                               LineBreakMode="WordWrap"
+                               TextColor="{DynamicResource TextLink}">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding OpenRootPathCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </VerticalStackLayout>
 
-                    <Grid ColumnDefinitions="*,*"
-                          ColumnSpacing="12">
-                        <Border Grid.Column="0"
-                                Padding="14"
-                                Background="{DynamicResource BackgroundTertiary}">
+                    <Border Grid.Column="1"
+                            Grid.Row="0"
+                            Padding="14,10"
+                            Background="{DynamicResource BackgroundTertiary}"
+                            StrokeShape="RoundRectangle 8">
+                        <VerticalStackLayout Spacing="6">
                             <Label Text="{Binding PreviewStatChanges}"
                                    FontSize="16"
                                    FontAttributes="Bold" />
-                        </Border>
-                        <Border Grid.Column="1"
-                                Padding="14"
-                                Background="{DynamicResource BackgroundTertiary}">
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <Border Grid.Column="2"
+                            Grid.Row="0"
+                            Padding="14,10"
+                            Background="{DynamicResource BackgroundTertiary}"
+                            StrokeShape="RoundRectangle 8">
+                        <VerticalStackLayout Spacing="6">
                             <Label Text="{Binding PreviewStatNotes}"
                                    FontSize="16"
                                    FontAttributes="Bold" />
-                        </Border>
-                    </Grid>
-                </VerticalStackLayout>
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
             </Border>
 
-            <VerticalStackLayout Spacing="12">
+            <VerticalStackLayout Spacing="10">
                 <Grid ColumnDefinitions="*,Auto"
                       ColumnSpacing="12">
                     <Label Text="{x:Static strings:AppStrings.PreviewOperationsSectionHeader}"
@@ -129,9 +170,6 @@
                            VerticalOptions="Center"
                            TextColor="{DynamicResource TextSecondary}" />
                 </Grid>
-                <Label Text="{x:Static strings:AppStrings.PreviewOperationsDescription}"
-                       FontSize="13"
-                       TextColor="{DynamicResource TextSecondary}" />
 
                 <VerticalStackLayout Spacing="0"
                                      BindableLayout.ItemsSource="{Binding Operations}">
@@ -141,19 +179,19 @@
                                 <Grid ColumnDefinitions="*,Auto"
                                       ColumnSpacing="12">
                                     <VerticalStackLayout Grid.Column="0"
-                                                         Spacing="4">
+                                                         Spacing="3">
                                         <Label Text="{Binding FromDisplay}"
-                                               FontSize="12"
+                                               FontSize="13"
                                                FontFamily="Courier New"
                                                TextColor="{DynamicResource TextMuted}"
                                                LineBreakMode="TailTruncation" />
                                         <Label Text="{Binding ToDisplay}"
-                                               FontSize="14"
+                                               FontSize="15"
                                                FontFamily="Courier New"
                                                FontAttributes="Bold"
                                                LineBreakMode="TailTruncation" />
                                         <Label Text="{Binding DateRangeText}"
-                                               FontSize="11"
+                                               FontSize="12"
                                                TextColor="{DynamicResource TextSecondary}" />
                                     </VerticalStackLayout>
 
@@ -173,6 +211,23 @@
                     </BindableLayout.ItemTemplate>
                 </VerticalStackLayout>
             </VerticalStackLayout>
+
+            <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                  ColumnSpacing="8">
+                <Button Grid.Column="0"
+                        Style="{DynamicResource CompactSecondaryButton}"
+                        Text="{x:Static strings:AppStrings.PreviewButtonBackToPlan}"
+                        Command="{Binding SelectStepCommand}"
+                        CommandParameter="{x:Static plans:PlanWorkflowStep.GeneratePlan}" />
+                <Button Grid.Column="2"
+                        Style="{DynamicResource CompactSecondaryButton}"
+                        Text="{x:Static strings:AppStrings.PreviewButtonReloadPlan}"
+                        Command="{Binding LoadPreviewCommand}" />
+                <Button Grid.Column="3"
+                        Text="{x:Static strings:AppStrings.PreviewButtonContinue}"
+                        Command="{Binding SelectStepCommand}"
+                        CommandParameter="{x:Static plans:PlanWorkflowStep.ApplyPlan}" />
+            </Grid>
         </VerticalStackLayout>
     </VerticalStackLayout>
 </ContentView>


### PR DESCRIPTION
## Summary

- Reconciles the Review workspace around the loaded-card concept: compact plan summary, stat cards, dense operation cards, and bottom action row.
- Reworks the Rename workspace into a compact apply card, hides redundant load/result sections by state, and tightens result details.
- Adds resource-backed Review action labels and softens the default Rename status copy.
- Marks slice 430 complete in `docs/checklists/v1.md`.

## Visual verification

- Review loaded card view captured locally: `/private/tmp/renamer-430-review-cards.png`
- Rename workspace captured locally: `/private/tmp/renamer-430-rename.png`

## Verification

- `dotnet restore Renamer.sln`
- `dotnet build src/Renamer.UI/Renamer.UI.csproj`
- `dotnet test src/Renamer.Tests/Renamer.Tests.csproj --filter "FullyQualifiedName~PlanOperation|FullyQualifiedName~Preview|FullyQualifiedName~Apply"`
- `dotnet build Renamer.sln`
- `dotnet test Renamer.sln`
